### PR TITLE
Add default configuration

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -37,6 +37,18 @@
         </arguments>
     </virtualType>
 
+   <!-- NotifierFactory and Notifier setup -->
+    <preference for="Aligent\AsyncEvents\Service\AsyncEvent\NotifierFactoryInterface"
+                type="Aligent\AsyncEvents\Service\AsyncEvent\NotifierFactory" />
+
+    <type name="Aligent\AsyncEvents\Service\AsyncEvent\NotifierFactory">
+        <arguments>
+            <argument name="notifierClasses" xsi:type="array">
+                <item name="http" xsi:type="object">Aligent\AsyncEvent\Service\AsyncEvent\HttpNotifier</item>
+            </argument>
+        </arguments>
+    </type>
+
     <!-- XML/XSD Config -->
     <type name="Aligent\AsyncEvents\Model\Config\Reader">
         <arguments>


### PR DESCRIPTION
Currently users have to install and configure a notifier factory setup however reference implementations are provided. I think it might be better to just configure it by default so that it's easier for people who are getting started to just play around and when they need a different notifier, they can dive deeper into the setup.

Instructions can be added in detail in the module documentation wiki.