### PR TITLE
Add uuid for events and retries

### DIFF
--- a/Helper/NotifierResult.php
+++ b/Helper/NotifierResult.php
@@ -18,6 +18,11 @@ class NotifierResult
      */
     private $_responseData;
 
+    /**
+     * @var string
+     */
+    private $uuid;
+
     public function getSuccess()
     {
         return $this->_success;
@@ -48,6 +53,17 @@ class NotifierResult
     public function setResponseData($responseData)
     {
         $this->_responseData = $responseData;
+        return $this;
+    }
+
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }
+
+    public function setUuid(string $uuid)
+    {
+        $this->uuid = $uuid;
         return $this;
     }
 }

--- a/Model/AsyncEventLog.php
+++ b/Model/AsyncEventLog.php
@@ -71,4 +71,14 @@ class AsyncEventLog extends AbstractModel
         $this->setData('response_data', $responseData);
         return $this;
     }
+
+    public function getUuid(): string
+    {
+        return (string) $this->getData('uuid');
+    }
+
+    public function setUuid(string $uuid)
+    {
+        $this->setData('uuid', $uuid);
+    }
 }

--- a/Service/AsyncEvent/EventDispatcher.php
+++ b/Service/AsyncEvent/EventDispatcher.php
@@ -9,6 +9,7 @@ use Aligent\AsyncEvents\Model\AsyncEventLogFactory;
 use Aligent\AsyncEvents\Model\AsyncEventLogRepository;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Exception\AlreadyExistsException;
+use Ramsey\Uuid\Uuid;
 
 class EventDispatcher
 {
@@ -89,10 +90,13 @@ class EventDispatcher
                 'data' => $output
             ]);
 
+            $uuid = Uuid::uuid4()->toString();
+            $response->setUuid($uuid);
+
             $this->log($response);
 
             if (!$response->getSuccess()) {
-                $this->retryManager->init($asyncEvent->getSubscriptionId(), $output);
+                $this->retryManager->init($asyncEvent->getSubscriptionId(), $output, $uuid);
             }
         }
     }
@@ -107,6 +111,7 @@ class EventDispatcher
         $asyncEventLog->setSuccess($response->getSuccess());
         $asyncEventLog->setSubscriptionId($response->getSubscriptionId());
         $asyncEventLog->setResponseData($response->getResponseData());
+        $asyncEventLog->setUuid($response->getUuid());
 
         try {
             $this->asyncEventLogRepository->save($asyncEventLog);

--- a/Service/AsyncEvent/RetryManager.php
+++ b/Service/AsyncEvent/RetryManager.php
@@ -22,6 +22,7 @@ class RetryManager
     const DEATH_COUNT = 'death_count';
     const SUBSCRIPTION_ID = 'subscription_id';
     const CONTENT = 'content';
+    const UUID = 'uuid';
 
     /**
      * @var ConfigPool
@@ -88,15 +89,17 @@ class RetryManager
     /**
      * @param int $subscriptionId
      * @param $data
+     * @param string
      * @return void
      */
-    public function init(int $subscriptionId, $data)
+    public function init(int $subscriptionId, $data, string $uuid)
     {
         $this->assertDelayQueue(1, QueueMetadataInterface::RETRY_INIT_ROUTING_KEY, QueueMetadataInterface::RETRY_INIT_ROUTING_KEY);
         $this->publisher->publish(QueueMetadataInterface::RETRY_INIT_ROUTING_KEY, [
             self::SUBSCRIPTION_ID => $subscriptionId,
             self::DEATH_COUNT => 1,
-            self::CONTENT => $this->serializer->serialize($data)
+            self::CONTENT => $this->serializer->serialize($data),
+            self::UUID => $uuid
         ]);
     }
 
@@ -104,9 +107,10 @@ class RetryManager
      * @param int $deathCount
      * @param int $subscriptionId
      * @param $data
+     * @param string $uuid
      * @return void
      */
-    public function place(int $deathCount, int $subscriptionId, $data)
+    public function place(int $deathCount, int $subscriptionId, $data, string $uuid)
     {
         $backoff = $this->calculateBackoff($deathCount);
         $queueName = 'event.delay.' . $backoff;
@@ -116,7 +120,8 @@ class RetryManager
         $this->publisher->publish($retryRoutingKey, [
             self::SUBSCRIPTION_ID => $subscriptionId,
             self::DEATH_COUNT =>  $deathCount,
-            self::CONTENT => $this->serializer->serialize($data)
+            self::CONTENT => $this->serializer->serialize($data),
+            self::UUID => $uuid
         ]);
     }
 

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -19,6 +19,7 @@
 
     <table name="async_event_subscriber_log">
         <column name="log_id" xsi:type="int" unsigned="true" identity="true" nullable="false"/>
+        <column name="uuid" xsi:type="varchar" nullable="true" />
         <column name="subscription_id" xsi:type="int" unsigned="true" nullable="false"/>
         <column name="success" xsi:type="boolean" nullable="false" />
         <column name="response_data" xsi:type="text" nullable="false" />
@@ -34,5 +35,9 @@
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="log_id"/>
         </constraint>
+
+        <index referenceId="ASYNC_EVENT_SUBSCRIBER_LOG_UUID" indexType="btree">
+            <column name="uuid"/>
+        </index>
     </table>
 </schema>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -20,11 +20,15 @@
             "subscription_id": true,
             "success": true,
             "response_data": true,
-            "created": true
+            "created": true,
+            "uuid": true
         },
         "constraint": {
             "FK_5DC4CE95673D2497179D07B60DE79F61": true,
             "PRIMARY": true
+        },
+        "index": {
+            "ASYNC_EVENT_SUBSCRIBER_LOG_UUID": true
         }
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -44,7 +44,7 @@
     <type name="Aligent\AsyncEvents\Service\AsyncEvent\NotifierFactory">
         <arguments>
             <argument name="notifierClasses" xsi:type="array">
-                <item name="http" xsi:type="object">Aligent\AsyncEvent\Service\AsyncEvent\HttpNotifier</item>
+                <item name="http" xsi:type="object">Aligent\AsyncEvents\Service\AsyncEvent\HttpNotifier</item>
             </argument>
         </arguments>
     </type>

--- a/view/adminhtml/ui_component/async_events_logs_listing.xml
+++ b/view/adminhtml/ui_component/async_events_logs_listing.xml
@@ -52,14 +52,21 @@
             </settings>
         </column>
 
-        <column name="subscription_id" sortOrder="20">
+        <column name="uuid" sortOrder="20">
+            <settings>
+                <filter>text</filter>
+                <label translate="true">uuid</label>
+            </settings>
+        </column>
+
+        <column name="subscription_id" sortOrder="30">
             <settings>
                 <filter>text</filter>
                 <label translate="true">Subscription</label>
             </settings>
         </column>
 
-        <column name="success" class="Aligent\AsyncEvents\Ui\Component\Listing\Columns\Status" sortOrder="30">
+        <column name="success" class="Aligent\AsyncEvents\Ui\Component\Listing\Columns\Status" sortOrder="40">
             <settings>
                 <filter>text</filter>
                 <label translate="true">Status</label>
@@ -70,7 +77,7 @@
             </settings>
         </column>
 
-        <column name="response_data" sortOrder="40">
+        <column name="response_data" sortOrder="50">
             <settings>
                 <filter>text</filter>
                 <label translate="true">Response</label>


### PR DESCRIPTION
Currently the module has a log listing grid which displays a grid collection of the logs available. The listing contains the initial attempts and any subsequent retries and does not differentiate between an initial attempt and a retry or group them by in any way.

![image](https://user-images.githubusercontent.com/40108018/146128417-6c1d3b01-341d-4770-b37a-d2641fb0ddc5.png)

This is fine but quickly becomes hard to see what’s going on when there are multiple subscribers for multiple events including retries. everything in the grid gets interleaved between different deliveries.

![image](https://user-images.githubusercontent.com/40108018/146128595-0c2d27a9-38cd-4ef3-b3e2-98772afd4cc9.png)

As a basic improvement, each log listing can carry an uuid. Logs that have the same uuid are part of the same 'barrel'. This makes it easier to identify between different subscribers and initial delivery and retries when they are interleaved.

