### PR TITLE
Trace, Replay Asynchronous Events

### DIFF
--- a/Block/Adminhtml/Trace/Details/BackButton.php
+++ b/Block/Adminhtml/Trace/Details/BackButton.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Aligent Consulting
+ * Copyright (c) Aligent Consulting (https://www.aligent.com.au)
+ */
+
+declare(strict_types=1);
+
+namespace Aligent\AsyncEvents\Block\Adminhtml\Trace\Details;
+
+use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+
+class BackButton implements ButtonProviderInterface
+{
+
+    /**
+     * URL builder
+     *
+     * @var UrlInterface
+     */
+    private $urlBuilder;
+
+    /**
+     * @param UrlInterface $urlBuilder
+     */
+    public function __construct(
+        UrlInterface $urlBuilder
+    ) {
+        $this->urlBuilder = $urlBuilder;
+    }
+
+    public function getButtonData(): array
+    {
+        return [
+            'label' => __('Back'),
+            'on_click' => sprintf("location.href = '%s';", $this->urlBuilder->getUrl('*/logs/index')),
+            'class' => 'back',
+            'sort_order' => 10
+        ];
+    }
+}

--- a/Block/Adminhtml/Trace/Details/ReplayButton.php
+++ b/Block/Adminhtml/Trace/Details/ReplayButton.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Aligent Consulting
+ * Copyright (c) Aligent Consulting (https://www.aligent.com.au)
+ */
+
+declare(strict_types=1);
+
+namespace Aligent\AsyncEvents\Block\Adminhtml\Trace\Details;
+
+use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
+
+class ReplayButton implements ButtonProviderInterface
+{
+
+    public function getButtonData()
+    {
+        return [
+            'label' => __('Replay'),
+            'class' => 'primary',
+            'data_attribute' => [
+                'mage-init' => [
+                    'button' => ['event' => 'save']
+                ],
+                'form-role' => 'save',
+            ],
+        ];
+    }
+}

--- a/Block/Adminhtml/Trace/Tab/View.php
+++ b/Block/Adminhtml/Trace/Tab/View.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Aligent Consulting
+ * Copyright (c) Aligent Consulting (https://www.aligent.com.au)
+ */
+
+declare(strict_types=1);
+
+namespace Aligent\AsyncEvents\Block\Adminhtml\Trace\Tab;
+
+use Magento\Backend\Block\Template;
+use Magento\Ui\Component\Layout\Tabs\TabInterface;
+
+class View extends Template implements TabInterface
+{
+
+    public function getTabLabel()
+    {
+        return __('Overview');
+    }
+
+    public function getTabTitle()
+    {
+        return __('Overview');
+    }
+
+    public function getTabClass()
+    {
+        return '';
+    }
+
+    public function getTabUrl()
+    {
+        return '';
+    }
+
+    public function isAjaxLoaded()
+    {
+        return false;
+    }
+
+    public function canShowTab()
+    {
+        return true;
+    }
+
+    public function isHidden()
+    {
+        return false;
+    }
+}

--- a/Block/Adminhtml/Trace/Tab/View/Info.php
+++ b/Block/Adminhtml/Trace/Tab/View/Info.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Aligent Consulting
+ * Copyright (c) Aligent Consulting (https://www.aligent.com.au)
+ */
+
+declare(strict_types=1);
+
+namespace Aligent\AsyncEvents\Block\Adminhtml\Trace\Tab\View;
+
+use Aligent\AsyncEvents\Model\Details;
+use Magento\Backend\Block\Template;
+use Magento\Backend\Block\Template\Context;
+
+class Info extends Template
+{
+    /**
+     * @var Details
+     */
+    private $details;
+
+    private $uuid;
+
+    public function __construct(
+        Context $context,
+        Details $details,
+        array $data = []
+    ) {
+        $this->details = $details;
+        parent::__construct($context, $data);
+        $this->uuid = $this->getRequest()->getParam('uuid');
+    }
+
+    public function getUuid()
+    {
+        return $this->uuid;
+    }
+
+    public function getLogs()
+    {
+        return $this->details->getLogs($this->uuid);
+    }
+
+    public function getStatus()
+    {
+        return $this->details->getStatus($this->uuid);
+    }
+
+    public function getFirstAttempt()
+    {
+        return $this->details->getFirstAttempt($this->uuid);
+    }
+
+    public function getLastAttempt()
+    {
+        return $this->details->getLastAttempt($this->uuid);
+    }
+
+    public function getAsynchronousEventName()
+    {
+        return $this->details->getAsynchronousEventName($this->uuid);
+    }
+
+    public function getCurrentStatus()
+    {
+        return $this->details->getCurrentStatus($this->uuid);
+    }
+
+    public function getRecipient()
+    {
+        return $this->details->getRecipient($this->uuid);
+    }
+
+    public function getSubscribedAt()
+    {
+        return $this->details->getSubscribedAt($this->uuid);
+    }
+}

--- a/Controller/Adminhtml/Events/Retry.php
+++ b/Controller/Adminhtml/Events/Retry.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Aligent Consulting
+ * Copyright (c) Aligent Consulting (https://www.aligent.com.au)
+ */
+
+declare(strict_types=1);
+
+namespace Aligent\AsyncEvents\Controller\Adminhtml\Events;
+
+use Aligent\AsyncEvents\Service\AsyncEvent\RetryManager;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Backend\App\Action;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Framework\View\Result\PageFactory;
+
+class Retry extends Action implements HttpPostActionInterface
+{
+
+    /**
+     * @var PageFactory
+     */
+    protected $resultPageFactory;
+
+    /**
+     * @var RetryManager
+     */
+    private $retryManager;
+
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    public function __construct(
+        Context $context,
+        PageFactory $resultPageFactory,
+        RetryManager $retryManager,
+        SerializerInterface $serializer
+    ) {
+        parent::__construct($context);
+        $this->resultPageFactory = $resultPageFactory;
+        $this->retryManager = $retryManager;
+        $this->serializer = $serializer;
+    }
+
+    public function execute()
+    {
+        $data = $this->getRequest()->getPostValue()['general'];
+
+        $this->retryManager->init((int) $data['subscription_id'], $this->serializer->unserialize($data['serialized_data'])['data'] , $data['uuid']);
+
+        $this->_redirect($this->_redirect->getRefererUrl());
+    }
+}

--- a/Controller/Adminhtml/Events/Retry.php
+++ b/Controller/Adminhtml/Events/Retry.php
@@ -51,7 +51,11 @@ class Retry extends Action implements HttpPostActionInterface
     {
         $data = $this->getRequest()->getPostValue()['general'];
 
-        $this->retryManager->init((int) $data['subscription_id'], $this->serializer->unserialize($data['serialized_data'])['data'] , $data['uuid']);
+        $this->retryManager->init(
+            (int) $data['subscription_id'],
+            $this->serializer->unserialize($data['serialized_data'])['data'] ,
+            $data['uuid']
+        );
 
         $this->_redirect($this->_redirect->getRefererUrl());
     }

--- a/Controller/Adminhtml/Logs/Trace.php
+++ b/Controller/Adminhtml/Logs/Trace.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aligent\AsyncEvents\Controller\Adminhtml\Logs;
+
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Action\HttpGetActionInterface;
+use Magento\Framework\View\Result\Page;
+use Magento\Framework\View\Result\PageFactory;
+
+class Trace extends Action implements HttpGetActionInterface
+{
+    const MENU_ID = 'Aligent_AsyncEvents::logs';
+
+    /**
+     * @var PageFactory
+     */
+    protected $resultPageFactory;
+
+    /**
+     * @param Context $context
+     * @param PageFactory $resultPageFactory
+     */
+    public function __construct(
+        Context $context,
+        PageFactory $resultPageFactory
+    ) {
+        parent::__construct($context);
+
+        $this->resultPageFactory = $resultPageFactory;
+    }
+
+    /**
+     * @return Page
+     */
+    public function execute()
+    {
+        $uuid = $this->getRequest()->getParam('uuid');
+
+        $resultPage = $this->resultPageFactory->create();
+        $resultPage->setActiveMenu(static::MENU_ID);
+        $resultPage->getConfig()->getTitle()->prepend(__('Trace'));
+
+        return $resultPage;
+    }
+}

--- a/Controller/Adminhtml/Logs/Trace.php
+++ b/Controller/Adminhtml/Logs/Trace.php
@@ -37,8 +37,6 @@ class Trace extends Action implements HttpGetActionInterface
      */
     public function execute()
     {
-        $uuid = $this->getRequest()->getParam('uuid');
-
         $resultPage = $this->resultPageFactory->create();
         $resultPage->setActiveMenu(static::MENU_ID);
         $resultPage->getConfig()->getTitle()->prepend(__('Trace'));

--- a/Helper/NotifierResult.php
+++ b/Helper/NotifierResult.php
@@ -23,6 +23,9 @@ class NotifierResult
      */
     private $uuid;
 
+    /**
+     * @var array
+     */
     private $data;
 
     public function getSuccess()
@@ -69,12 +72,19 @@ class NotifierResult
         return $this;
     }
 
-    public function setAsyncEventData($eventData)
+    /**
+     * @param array $eventData
+     * @return void
+     */
+    public function setAsyncEventData(array $eventData)
     {
         $this->data = $eventData;
     }
 
-    public function getAsyncEventData()
+    /**
+     * @return array
+     */
+    public function getAsyncEventData(): array
     {
         return $this->data;
     }

--- a/Helper/NotifierResult.php
+++ b/Helper/NotifierResult.php
@@ -23,6 +23,8 @@ class NotifierResult
      */
     private $uuid;
 
+    private $data;
+
     public function getSuccess()
     {
         return $this->_success;
@@ -65,5 +67,15 @@ class NotifierResult
     {
         $this->uuid = $uuid;
         return $this;
+    }
+
+    public function setAsyncEventData($eventData)
+    {
+        $this->data = $eventData;
+    }
+
+    public function getAsyncEventData()
+    {
+        return $this->data;
     }
 }

--- a/Model/AsyncEventLog.php
+++ b/Model/AsyncEventLog.php
@@ -81,4 +81,14 @@ class AsyncEventLog extends AbstractModel
     {
         $this->setData('uuid', $uuid);
     }
+
+    public function getSerializedData()
+    {
+        return $this->getData('serialized_data');
+    }
+
+    public function setSerializedData($serializedData)
+    {
+        $this->setData('serialized_data', $serializedData);
+    }
 }

--- a/Model/AsyncEventLog.php
+++ b/Model/AsyncEventLog.php
@@ -82,12 +82,12 @@ class AsyncEventLog extends AbstractModel
         $this->setData('uuid', $uuid);
     }
 
-    public function getSerializedData()
+    public function getSerializedData(): array
     {
         return $this->getData('serialized_data');
     }
 
-    public function setSerializedData($serializedData)
+    public function setSerializedData(array $serializedData)
     {
         $this->setData('serialized_data', $serializedData);
     }

--- a/Model/Details.php
+++ b/Model/Details.php
@@ -42,7 +42,6 @@ class Details
     /**
      * @param string $uuid
      * @return array
-     * @throws NoSuchEntityException
      */
     public function getDetails(string $uuid): array
     {
@@ -50,22 +49,24 @@ class Details
             return $this->traceCache[$uuid];
         }
 
+        /** @var Collection $collection */
         $collection = $this->collectionFactory->create();
         $collection->addFilter('uuid', $uuid);
 
         $traces = $collection->toArray();
 
-        if ($traces['totalRecords'] === 0) {
-            return [];
-        }
-
         $asyncEventId = $collection->getFirstItem()->getData('subscription_id');
-        $asyncEvent = $this->asyncEventRepository->get($asyncEventId)->getData();
 
-        $this->traceCache[$uuid] = [
-            'traces' => $traces['items'],
-            'async_event' => $asyncEvent
-        ];
+        try {
+            $asyncEvent = $this->asyncEventRepository->get($asyncEventId)->getData();
+            $this->traceCache[$uuid] = [
+                'traces' => $traces['items'],
+                'async_event' => $asyncEvent
+            ];
+
+        } catch (NoSuchEntityException $exception) {
+            // Do nothing because an uuid cannot exist without its subscription
+        }
 
         return $this->traceCache[$uuid];
     }
@@ -73,7 +74,6 @@ class Details
     /**
      * @param string $uuid
      * @return array
-     * @throws NoSuchEntityException
      */
     public function getLogs(string $uuid): array
     {
@@ -85,7 +85,6 @@ class Details
     /**
      * @param string $uuid
      * @return string
-     * @throws NoSuchEntityException
      */
     public function getStatus(string $uuid): string
     {
@@ -123,7 +122,6 @@ class Details
     /**
      * @param string $uuid
      * @return string
-     * @throws NoSuchEntityException
      */
     public function getFirstAttempt(string $uuid): string
     {
@@ -138,7 +136,6 @@ class Details
     /**
      * @param string $uuid
      * @return string
-     * @throws NoSuchEntityException
      */
     public function getLastAttempt(string $uuid): string
     {
@@ -153,7 +150,6 @@ class Details
     /**
      * @param string $uuid
      * @return string
-     * @throws NoSuchEntityException
      */
     public function getAsynchronousEventName(string $uuid): string
     {
@@ -167,7 +163,6 @@ class Details
     /**
      * @param string $uuid
      * @return string
-     * @throws NoSuchEntityException
      */
     public function getCurrentStatus(string $uuid): string
     {
@@ -181,7 +176,6 @@ class Details
     /**
      * @param string $uuid
      * @return string
-     * @throws NoSuchEntityException
      */
     public function getRecipient(string $uuid): string
     {
@@ -195,7 +189,6 @@ class Details
     /**
      * @param string $uuid
      * @return string
-     * @throws NoSuchEntityException
      */
     public function getSubscribedAt(string $uuid): string
     {

--- a/Model/Details.php
+++ b/Model/Details.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * Aligent Consulting
+ * Copyright (c) Aligent Consulting (https://www.aligent.com.au)
+ */
+
+declare(strict_types=1);
+
+namespace Aligent\AsyncEvents\Model;
+
+use Aligent\AsyncEvents\Api\AsyncEventRepositoryInterface;
+use Aligent\AsyncEvents\Model\ResourceModel\AsyncEventLog\Collection;
+use Aligent\AsyncEvents\Model\ResourceModel\AsyncEventLog\CollectionFactory as AsyncEventLogCollectionFactory;
+
+class Details
+{
+    /**
+     * @var array
+     */
+    private $traceCache = [];
+
+    /**
+     * @var Collection
+     */
+    private $collection;
+
+    /**
+     * @var AsyncEventRepositoryInterface
+     */
+    private $asyncEventRepository;
+
+    public function __construct(
+        AsyncEventLogCollectionFactory $collectionFactory,
+        AsyncEventRepositoryInterface  $asyncEventRepository
+    ) {
+        $this->collection = $collectionFactory->create();
+        $this->asyncEventRepository = $asyncEventRepository;
+    }
+
+    public function getDetails($uuid)
+    {
+        if (array_key_exists($uuid, $this->traceCache)) {
+            return $this->traceCache[$uuid];
+        }
+
+        $this->collection->addFilter('uuid', $uuid);
+
+        $traces = $this->collection->toArray();
+
+        if ($traces['totalRecords'] === 0) {
+            return [];
+        }
+
+        $asyncEventId = $this->collection->getFirstItem()->getData('subscription_id');
+        $asyncEvent = $this->asyncEventRepository->get($asyncEventId)->getData();
+
+        $this->traceCache[$uuid] = [
+            'traces' => $traces['items'],
+            'async_event' => $asyncEvent
+        ];
+
+        return $this->traceCache[$uuid];
+    }
+
+    public function getLogs($uuid)
+    {
+        $this->getDetails($uuid);
+
+        return $this->traceCache[$uuid]['traces'];
+    }
+
+    public function getStatus($uuid)
+    {
+        $this->getDetails($uuid);
+
+        $traces = $this->traceCache[$uuid]['traces'];
+
+        $deathCount = 0;
+        $success = false;
+        foreach ($traces as $trace) {
+            if (!$trace['success']) {
+                $deathCount++;
+            } else {
+                $success = true;
+                break;
+            }
+        }
+
+        if ($success) {
+            $message = 'Delivered';
+        } else {
+            $message = 'Dead Lettered';
+        }
+
+        if ($deathCount > 0) {
+            $message = $message . ' with ' . $deathCount . ' retries';
+        }
+
+        return $message;
+    }
+
+    public function getFirstAttempt($uuid)
+    {
+        $this->getDetails($uuid);
+
+        $traces = $this->traceCache[$uuid]['traces'];
+        $firstTrace = current($traces);
+
+        return $firstTrace['created'];
+    }
+
+    public function getLastAttempt($uuid)
+    {
+        $this->getDetails($uuid);
+
+        $traces = $this->traceCache[$uuid]['traces'];
+        $firstTrace = end($traces);
+
+        return $firstTrace['created'];
+    }
+
+    public function getAsynchronousEventName($uuid)
+    {
+        $this->getDetails($uuid);
+
+        $event = $this->traceCache[$uuid]['async_event'];
+
+        return $event['event_name'];
+    }
+
+    public function getCurrentStatus($uuid)
+    {
+        $this->getDetails($uuid);
+
+        $event = $this->traceCache[$uuid]['async_event'];
+
+        return $event['status'] ? 'Enabled' : 'Disabled';
+    }
+
+    public function getRecipient($uuid)
+    {
+        $this->getDetails($uuid);
+
+        $event = $this->traceCache[$uuid]['async_event'];
+
+        return $event['recipient_url'];
+    }
+
+    public function getSubscribedAt($uuid)
+    {
+        $this->getDetails($uuid);
+
+        $event = $this->traceCache[$uuid]['async_event'];
+
+        return $event['subscribed_at'];
+    }
+
+    public function getPlaceHolder()
+    {
+        return 'Placeholder';
+    }
+}

--- a/Model/Details.php
+++ b/Model/Details.php
@@ -12,6 +12,7 @@ namespace Aligent\AsyncEvents\Model;
 use Aligent\AsyncEvents\Api\AsyncEventRepositoryInterface;
 use Aligent\AsyncEvents\Model\ResourceModel\AsyncEventLog\Collection;
 use Aligent\AsyncEvents\Model\ResourceModel\AsyncEventLog\CollectionFactory as AsyncEventLogCollectionFactory;
+use Magento\Framework\Exception\NoSuchEntityException;
 
 class Details
 {
@@ -21,38 +22,44 @@ class Details
     private $traceCache = [];
 
     /**
-     * @var Collection
-     */
-    private $collection;
-
-    /**
      * @var AsyncEventRepositoryInterface
      */
     private $asyncEventRepository;
+
+    /**
+     * @var AsyncEventLogCollectionFactory
+     */
+    private $collectionFactory;
 
     public function __construct(
         AsyncEventLogCollectionFactory $collectionFactory,
         AsyncEventRepositoryInterface  $asyncEventRepository
     ) {
-        $this->collection = $collectionFactory->create();
         $this->asyncEventRepository = $asyncEventRepository;
+        $this->collectionFactory = $collectionFactory;
     }
 
-    public function getDetails($uuid)
+    /**
+     * @param string $uuid
+     * @return array
+     * @throws NoSuchEntityException
+     */
+    public function getDetails(string $uuid): array
     {
         if (array_key_exists($uuid, $this->traceCache)) {
             return $this->traceCache[$uuid];
         }
 
-        $this->collection->addFilter('uuid', $uuid);
+        $collection = $this->collectionFactory->create();
+        $collection->addFilter('uuid', $uuid);
 
-        $traces = $this->collection->toArray();
+        $traces = $collection->toArray();
 
         if ($traces['totalRecords'] === 0) {
             return [];
         }
 
-        $asyncEventId = $this->collection->getFirstItem()->getData('subscription_id');
+        $asyncEventId = $collection->getFirstItem()->getData('subscription_id');
         $asyncEvent = $this->asyncEventRepository->get($asyncEventId)->getData();
 
         $this->traceCache[$uuid] = [
@@ -63,14 +70,24 @@ class Details
         return $this->traceCache[$uuid];
     }
 
-    public function getLogs($uuid)
+    /**
+     * @param string $uuid
+     * @return array
+     * @throws NoSuchEntityException
+     */
+    public function getLogs(string $uuid): array
     {
         $this->getDetails($uuid);
 
         return $this->traceCache[$uuid]['traces'];
     }
 
-    public function getStatus($uuid)
+    /**
+     * @param string $uuid
+     * @return string
+     * @throws NoSuchEntityException
+     */
+    public function getStatus(string $uuid): string
     {
         $this->getDetails($uuid);
 
@@ -103,7 +120,12 @@ class Details
         return $message;
     }
 
-    public function getFirstAttempt($uuid)
+    /**
+     * @param string $uuid
+     * @return string
+     * @throws NoSuchEntityException
+     */
+    public function getFirstAttempt(string $uuid): string
     {
         $this->getDetails($uuid);
 
@@ -113,7 +135,12 @@ class Details
         return $firstTrace['created'];
     }
 
-    public function getLastAttempt($uuid)
+    /**
+     * @param string $uuid
+     * @return string
+     * @throws NoSuchEntityException
+     */
+    public function getLastAttempt(string $uuid): string
     {
         $this->getDetails($uuid);
 
@@ -123,7 +150,12 @@ class Details
         return $firstTrace['created'];
     }
 
-    public function getAsynchronousEventName($uuid)
+    /**
+     * @param string $uuid
+     * @return string
+     * @throws NoSuchEntityException
+     */
+    public function getAsynchronousEventName(string $uuid): string
     {
         $this->getDetails($uuid);
 
@@ -132,7 +164,12 @@ class Details
         return $event['event_name'];
     }
 
-    public function getCurrentStatus($uuid)
+    /**
+     * @param string $uuid
+     * @return string
+     * @throws NoSuchEntityException
+     */
+    public function getCurrentStatus(string $uuid): string
     {
         $this->getDetails($uuid);
 
@@ -141,7 +178,12 @@ class Details
         return $event['status'] ? 'Enabled' : 'Disabled';
     }
 
-    public function getRecipient($uuid)
+    /**
+     * @param string $uuid
+     * @return string
+     * @throws NoSuchEntityException
+     */
+    public function getRecipient(string $uuid): string
     {
         $this->getDetails($uuid);
 
@@ -150,17 +192,17 @@ class Details
         return $event['recipient_url'];
     }
 
-    public function getSubscribedAt($uuid)
+    /**
+     * @param string $uuid
+     * @return string
+     * @throws NoSuchEntityException
+     */
+    public function getSubscribedAt(string $uuid): string
     {
         $this->getDetails($uuid);
 
         $event = $this->traceCache[$uuid]['async_event'];
 
         return $event['subscribed_at'];
-    }
-
-    public function getPlaceHolder()
-    {
-        return 'Placeholder';
     }
 }

--- a/Model/Details.php
+++ b/Model/Details.php
@@ -79,13 +79,16 @@ class Details
         $deathCount = 0;
         $success = false;
         foreach ($traces as $trace) {
-            if (!$trace['success']) {
-                $deathCount++;
-            } else {
+            $deathCount++;
+
+            if ($trace['success']) {
                 $success = true;
                 break;
             }
         }
+
+        // Deduct one which is taking the initial delivery into consideration
+        $deathCount--;
 
         if ($success) {
             $message = 'Delivered';

--- a/Model/ResourceModel/AsyncEventLog.php
+++ b/Model/ResourceModel/AsyncEventLog.php
@@ -2,8 +2,12 @@
 
 namespace Aligent\AsyncEvents\Model\ResourceModel;
 
-class AsyncEventLog extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+
+class AsyncEventLog extends AbstractDb
 {
+
+    protected $_serializableFields = ['serialized_data' => [[],[]]];
 
     protected function _construct()
     {

--- a/Model/ResourceModel/AsyncEventLog/Collection.php
+++ b/Model/ResourceModel/AsyncEventLog/Collection.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Aligent Consulting
+ * Copyright (c) Aligent Consulting (https://www.aligent.com.au)
+ */
+
+declare(strict_types=1);
+
+namespace Aligent\AsyncEvents\Model\ResourceModel\AsyncEventLog;
+
+use Aligent\AsyncEvents\Model\AsyncEventLog;
+use Aligent\AsyncEvents\Model\ResourceModel\AsyncEventLog as AsyncEventLogResource;
+use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+
+class Collection extends AbstractCollection
+{
+    /**
+     * @var string
+     */
+    protected $_idFieldName = 'log_id';
+
+    protected function _construct()
+    {
+        $this->_init(
+            AsyncEventLog::class,
+            AsyncEventLogResource::class
+        );
+    }
+}

--- a/Model/RetryHandler.php
+++ b/Model/RetryHandler.php
@@ -130,11 +130,13 @@ class RetryHandler
      */
     private function log(NotifierResult $response)
     {
+        /** @var AsyncEventLog $asyncEventLog */
         $asyncEventLog = $this->asyncEventLogFactory->create();
         $asyncEventLog->setSuccess($response->getSuccess());
         $asyncEventLog->setSubscriptionId($response->getSubscriptionId());
         $asyncEventLog->setResponseData($response->getResponseData());
         $asyncEventLog->setUuid($response->getUuid());
+        $asyncEventLog->setSerializedData($response->getAsyncEventData());
 
         try {
             $this->asyncEventLogRepository->save($asyncEventLog);

--- a/Service/AsyncEvent/EventDispatcher.php
+++ b/Service/AsyncEvent/EventDispatcher.php
@@ -9,8 +9,8 @@ use Aligent\AsyncEvents\Model\AsyncEventLog;
 use Aligent\AsyncEvents\Model\AsyncEventLogFactory;
 use Aligent\AsyncEvents\Model\AsyncEventLogRepository;
 use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\DataObject\IdentityGeneratorInterface;
 use Magento\Framework\Exception\AlreadyExistsException;
-use Ramsey\Uuid\Uuid;
 
 class EventDispatcher
 {
@@ -45,11 +45,17 @@ class EventDispatcher
     private $retryManager;
 
     /**
+     * @var IdentityGeneratorInterface
+     */
+    private $identityService;
+
+    /**
      * @param AsyncEventRepositoryInterface $asyncEventRepository
      * @param AsyncEventLogRepository $asyncEventLogRepository
      * @param SearchCriteriaBuilder $searchCriteriaBuilder
      * @param NotifierFactoryInterface $notifierFactory
      * @param AsyncEventLogFactory $asyncEventLogFactory
+     * @param IdentityGeneratorInterface $identityService
      * @param RetryManager $retryManager
      */
     public function __construct(
@@ -58,6 +64,7 @@ class EventDispatcher
         SearchCriteriaBuilder         $searchCriteriaBuilder,
         NotifierFactoryInterface      $notifierFactory,
         AsyncEventLogFactory          $asyncEventLogFactory,
+        IdentityGeneratorInterface    $identityService,
         RetryManager                  $retryManager
     ) {
         $this->asyncEventRepository = $asyncEventRepository;
@@ -66,6 +73,7 @@ class EventDispatcher
         $this->asyncEventLogRepository = $asyncEventLogRepository;
         $this->asyncEventLogFactory = $asyncEventLogFactory;
         $this->retryManager = $retryManager;
+        $this->identityService = $identityService;
     }
 
     /**
@@ -91,7 +99,7 @@ class EventDispatcher
                 'data' => $output
             ]);
 
-            $uuid = Uuid::uuid4()->toString();
+            $uuid = $this->identityService->generateId();
             $response->setUuid($uuid);
 
             $this->log($response);

--- a/Service/AsyncEvent/EventDispatcher.php
+++ b/Service/AsyncEvent/EventDispatcher.php
@@ -5,6 +5,7 @@ namespace Aligent\AsyncEvents\Service\AsyncEvent;
 use Aligent\AsyncEvents\Api\AsyncEventRepositoryInterface;
 use Aligent\AsyncEvents\Helper\NotifierResult;
 use Aligent\AsyncEvents\Model\AsyncEvent;
+use Aligent\AsyncEvents\Model\AsyncEventLog;
 use Aligent\AsyncEvents\Model\AsyncEventLogFactory;
 use Aligent\AsyncEvents\Model\AsyncEventLogRepository;
 use Magento\Framework\Api\SearchCriteriaBuilder;
@@ -107,11 +108,13 @@ class EventDispatcher
      */
     private function log(NotifierResult $response)
     {
+        /** @var AsyncEventLog $asyncEventLog */
         $asyncEventLog = $this->asyncEventLogFactory->create();
         $asyncEventLog->setSuccess($response->getSuccess());
         $asyncEventLog->setSubscriptionId($response->getSubscriptionId());
         $asyncEventLog->setResponseData($response->getResponseData());
         $asyncEventLog->setUuid($response->getUuid());
+        $asyncEventLog->setSerializedData($response->getAsyncEventData());
 
         try {
             $this->asyncEventLogRepository->save($asyncEventLog);

--- a/Service/AsyncEvent/HttpNotifier.php
+++ b/Service/AsyncEvent/HttpNotifier.php
@@ -67,6 +67,7 @@ class HttpNotifier implements NotifierInterface
 
         $notifierResult = new NotifierResult();
         $notifierResult->setSubscriptionId($asyncEvent->getSubscriptionId());
+        $notifierResult->setAsyncEventData($body);
 
         try {
             $response = $this->client->post(
@@ -84,15 +85,12 @@ class HttpNotifier implements NotifierInterface
                 && $response->getStatusCode() < 300
             );
 
-            $notifierResult->setResponseData(
-                $this->json->serialize(
-                    $response->getBody()->getContents()
-                )
-            );
+            $notifierResult->setResponseData($response->getBody()->getContents());
+
         } catch (RequestException $exception) {
 
             /**
-             * Catch a RequestException so we cover even the network layer exceptions which might sometimes
+             * Catch a RequestException, so we cover even the network layer exceptions which might sometimes
              * not have a response.
              */
             $notifierResult->setSuccess(false);
@@ -102,11 +100,7 @@ class HttpNotifier implements NotifierInterface
                 $responseContent = $response->getBody()->getContents();
                 $exceptionMessage = !empty($responseContent) ? $responseContent : $response->getReasonPhrase();
 
-                $notifierResult->setResponseData(
-                    $this->json->serialize(
-                        $exceptionMessage
-                    )
-                );
+                $notifierResult->setResponseData($exceptionMessage);
             } else {
                 $notifierResult->setResponseData(
                     $exception->getMessage()

--- a/Ui/Component/Listing/Columns/AsyncEventActions.php
+++ b/Ui/Component/Listing/Columns/AsyncEventActions.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Aligent\AsyncEvents\Ui\Component\Listing\Columns;
+
+use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Element\UiComponent\ContextInterface;
+use Magento\Framework\View\Element\UiComponentFactory;
+use Magento\Ui\Component\Listing\Columns\Column;
+
+class AsyncEventActions extends Column
+{
+
+    const URL_PATH_TRACE = 'async_events/logs/trace';
+
+    /**
+     * @var UrlInterface
+     */
+    private $urlBuilder;
+
+    public function __construct(
+        ContextInterface $context,
+        UrlInterface $urlBuilder,
+        UiComponentFactory $uiComponentFactory,
+        array $components = [],
+        array $data = []
+    ) {
+        $this->urlBuilder = $urlBuilder;
+        parent::__construct($context, $uiComponentFactory, $components, $data);
+    }
+
+    public function prepareDataSource(array $dataSource)
+    {
+        if (isset($dataSource['data']['items'])) {
+            foreach ($dataSource['data']['items'] as &$item) {
+                if (isset($item['uuid'])) {
+                    $item[$this->getData('name')] = [
+                        'trace' => [
+                            'href' => $this->urlBuilder->getUrl(
+                                self::URL_PATH_TRACE,
+                                [
+                                    'uuid' => $item['uuid']
+                                ]
+                            ),
+                            'label' => __('Trace'),
+                        ]
+                    ];
+                }
+            }
+        }
+        return $dataSource;
+    }
+}

--- a/Ui/DataProvider/AsyncEventsTrace.php
+++ b/Ui/DataProvider/AsyncEventsTrace.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Aligent Consulting
+ * Copyright (c) Aligent Consulting (https://www.aligent.com.au)
+ */
+
+declare(strict_types=1);
+
+namespace Aligent\AsyncEvents\Ui\DataProvider;
+
+use Aligent\AsyncEvents\Model\Details;
+use Aligent\AsyncEvents\Model\ResourceModel\AsyncEventLog\Collection;
+use Magento\Framework\App\RequestInterface;
+use Magento\Ui\DataProvider\AbstractDataProvider;
+use Aligent\AsyncEvents\Model\ResourceModel\AsyncEventLog\CollectionFactory as AsyncEventLogCollectionFactory;
+
+class AsyncEventsTrace extends AbstractDataProvider
+{
+
+    /**
+     * @var Collection
+     */
+    protected $collection;
+
+    /**
+     * @var Details
+     */
+    private $traceDetails;
+
+    /**
+     * @var RequestInterface
+     */
+    private $request;
+
+    /**
+     * @param string $name
+     * @param string $primaryFieldName
+     * @param string $requestFieldName
+     * @param AsyncEventLogCollectionFactory $collectionFactory
+     * @param Details $traceDetails
+     * @param RequestInterface $request
+     * @param array $meta
+     * @param array $data
+     */
+    public function __construct(
+        $name,
+        $primaryFieldName,
+        $requestFieldName,
+        AsyncEventLogCollectionFactory $collectionFactory,
+        Details $traceDetails,
+        RequestInterface $request,
+        array $meta = [],
+        array $data = []
+    ) {
+        $this->collection = $collectionFactory->create();
+        $this->traceDetails = $traceDetails;
+        $this->request = $request;
+        parent::__construct($name, $primaryFieldName, $requestFieldName, $meta, $data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getData()
+    {
+        $uuid = $this->request->getParam($this->requestFieldName);
+        $details = $this->traceDetails->getDetails($uuid);
+
+        return [
+            $uuid => [
+                'general' => current($details['traces'])
+            ]
+        ];
+    }
+}

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -24,6 +24,8 @@
         <column name="success" xsi:type="boolean" nullable="false" />
         <column name="response_data" xsi:type="text" nullable="false" />
         <column name="created" xsi:type="datetime" default="CURRENT_TIMESTAMP" nullable="false"/>
+        <column xsi:type="blob" name="serialized_data" nullable="true"
+                comment="Data (serialized) that is associated with a delivery." />
 
         <constraint xsi:type="foreign" referenceId="FK_5DC4CE95673D2497179D07B60DE79F61"
                     table="async_event_subscriber_log"

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -17,7 +17,7 @@
         </constraint>
     </table>
 
-    <table name="async_event_subscriber_log">
+    <table name="async_event_subscriber_log" charset="utf8mb4" collation="utf8mb4_unicode_ci">
         <column name="log_id" xsi:type="int" unsigned="true" identity="true" nullable="false"/>
         <column name="uuid" xsi:type="varchar" nullable="true" />
         <column name="subscription_id" xsi:type="int" unsigned="true" nullable="false"/>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -21,7 +21,8 @@
             "success": true,
             "response_data": true,
             "created": true,
-            "uuid": true
+            "uuid": true,
+            "serialized_data": true
         },
         "constraint": {
             "FK_5DC4CE95673D2497179D07B60DE79F61": true,

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -26,6 +26,7 @@
                     Aligent\AsyncEvents\Model\ResourceModel\AsyncEvent\Grid\Collection
                 </item>
                 <item name="async_events_logs_listing_data_source" xsi:type="string">Aligent\AsyncEvents\Model\ResourceModel\WebhookLogs\Grid\Collection</item>
+                <item name="async_events_logs_trace_data_source" xsi:type="string">Aligent\AsyncEvents\Model\ResourceModel\WebhookLogs\Grid\Collection</item>
             </argument>
         </arguments>
     </type>

--- a/view/adminhtml/layout/async_events_logs_trace.xml
+++ b/view/adminhtml/layout/async_events_logs_trace.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd"
+      layout="admin-2columns-left">
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="async_events_logs_trace"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/templates/tab/view.phtml
+++ b/view/adminhtml/templates/tab/view.phtml
@@ -1,0 +1,8 @@
+<?php
+
+use Aligent\AsyncEvents\Block\Adminhtml\Trace\Tab\View;
+
+/** @var $block View */
+?>
+
+<?= $block->getChildHtml(); ?>

--- a/view/adminhtml/templates/tab/view/info.phtml
+++ b/view/adminhtml/templates/tab/view/info.phtml
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * @var Info $block
+ */
+use Aligent\AsyncEvents\Block\Adminhtml\Trace\Tab\View\Info;
+
+?>
+
+<section class="admin__page-section order-view-account-information">
+    <div class="admin__page-section-content">
+        <div class="admin__page-section-item order-information">
+            <div class="admin__page-section-item-title">
+                <span class="title">Async Event Delivery Information</span>
+            </div>
+
+            <div class="admin__page-section-item-content">
+                <table class="admin__table-secondary order-information-table">
+                    <tbody>
+                    <?= $block->getChildHtml() ?>
+                    <tr>
+                        <th><?= 'uuid' ?></th>
+                        <td><?= $block->getUuid() ?></td>
+                    </tr>
+                    <tr>
+                        <th><?= 'Status' ?></th>
+                        <td><?= $block->getStatus() ?></td>
+                    </tr>
+                    <tr>
+                        <th><?= 'First attempt time' ?></th>
+                        <td><?= $block->getFirstAttempt() ?></td>
+                    </tr>
+                    <tr>
+                        <th><?= 'Last attempt time' ?></th>
+                        <td><?= $block->getLastAttempt() ?></td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="admin__page-section-item order-account-information">
+            <div class="admin__page-section-item-title">
+                <span class="title">Subscription Information</span>
+            </div>
+
+            <div class="admin__page-section-item-content">
+                <table class="admin__table-secondary order-account-information-table">
+                    <?php $block->getLogs() ?>
+                    <tr>
+                        <th>Asynchronous Event Name</th>
+                        <td>
+                            <?= $block->getAsynchronousEventName() ?>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Current Status</th>
+                        <td>
+                            <?= $block->getCurrentStatus() ?>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Recipient</th>
+                        <td>
+                            <?= $block->getRecipient() ?>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Subscribed At</th>
+                        <td>
+                            <?= $block->getSubscribedAt() ?>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+</section>
+
+<div class="fieldset-wrapper">
+    <div class="fieldset-wrapper-title">
+        <span class="title"><?= 'Traces' ?></span>
+    </div>
+</div>
+
+<section class="">
+    <div class=>
+        <div class="">
+            <div class=>
+                <table class="">
+                    <thead>
+                        <tr>
+                            <th><?= __('Log Id') ?></th>
+                            <th><?= __('Delivery Time') ?></th>
+                            <th><?= __('uuid') ?></th>
+                            <th><?= __('Response') ?></th>
+                            <th><?= __('Status') ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    <?php foreach ($block->getLogs() as $item): ?>
+                        <tr>
+                            <td style="padding: 1rem">
+                                <?= $item['log_id'] ?>
+                            </td>
+                            <td style="padding: 1rem">
+                                <?= $item['created'] ?>
+                            </td>
+                            <td style="padding: 1rem">
+                                <?= $item['uuid'] ?>
+                            </td>
+                            <td style="padding: 1rem">
+                                <?= $item['response_data'] ?>
+                            </td>
+                            <td style="padding: 1rem">
+                                <?= $item['success'] ? 'Success' : 'Failed' ?>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</section>

--- a/view/adminhtml/templates/tab/view/info.phtml
+++ b/view/adminhtml/templates/tab/view/info.phtml
@@ -18,13 +18,13 @@ use Aligent\AsyncEvents\Block\Adminhtml\Trace\Tab\View\Info;
                 <table class="admin__table-secondary order-information-table">
                     <tbody>
                     <?= $block->getChildHtml() ?>
-                    <tr>
+                    <tr class="">
                         <th><?= 'uuid' ?></th>
                         <td><?= $block->getUuid() ?></td>
                     </tr>
                     <tr>
-                        <th><?= 'Status' ?></th>
-                        <td><?= $block->getStatus() ?></td>
+                        <th style="font-weight: bold"><?= 'Status' ?></th>
+                        <td style="font-weight: bold"><?= $block->getStatus() ?></td>
                     </tr>
                     <tr>
                         <th><?= 'First attempt time' ?></th>
@@ -81,45 +81,39 @@ use Aligent\AsyncEvents\Block\Adminhtml\Trace\Tab\View\Info;
     <div class="fieldset-wrapper-title">
         <span class="title"><?= 'Traces' ?></span>
     </div>
+    <div class="admin__table-wrapper">
+        <table class="admin__table-primary">
+            <thead>
+            <tr>
+                <th><?= __('Log Id') ?></th>
+                <th><?= __('Delivery Time') ?></th>
+                <th><?= __('uuid') ?></th>
+                <th><?= __('Response') ?></th>
+                <th><?= __('Status') ?></th>
+            </tr>
+            </thead>
+            <tbody>
+            <?php foreach ($block->getLogs() as $item): ?>
+                <tr>
+                    <td style="padding: 1rem">
+                        <?= $item['log_id'] ?>
+                    </td>
+                    <td style="padding: 1rem">
+                        <?= $item['created'] ?>
+                    </td>
+                    <td style="padding: 1rem">
+                        <?= $item['uuid'] ?>
+                    </td>
+                    <td style="padding: 1rem">
+                        <?= $item['response_data'] ?>
+                    </td>
+                    <td style="padding: 1rem" class="col-severity">
+                        <?= $item['success'] ? '<span class="grid-severity-notice"><span>Success</span></span>' : '<span class="grid-severity-critical"><span>Failed</span></span>' ?>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
 </div>
 
-<section class="">
-    <div class=>
-        <div class="">
-            <div class=>
-                <table class="">
-                    <thead>
-                        <tr>
-                            <th><?= __('Log Id') ?></th>
-                            <th><?= __('Delivery Time') ?></th>
-                            <th><?= __('uuid') ?></th>
-                            <th><?= __('Response') ?></th>
-                            <th><?= __('Status') ?></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                    <?php foreach ($block->getLogs() as $item): ?>
-                        <tr>
-                            <td style="padding: 1rem">
-                                <?= $item['log_id'] ?>
-                            </td>
-                            <td style="padding: 1rem">
-                                <?= $item['created'] ?>
-                            </td>
-                            <td style="padding: 1rem">
-                                <?= $item['uuid'] ?>
-                            </td>
-                            <td style="padding: 1rem">
-                                <?= $item['response_data'] ?>
-                            </td>
-                            <td style="padding: 1rem">
-                                <?= $item['success'] ? 'Success' : 'Failed' ?>
-                            </td>
-                        </tr>
-                    <?php endforeach; ?>
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
-</section>

--- a/view/adminhtml/ui_component/async_events_logs_listing.xml
+++ b/view/adminhtml/ui_component/async_events_logs_listing.xml
@@ -91,5 +91,6 @@
                 <label translate="true">Delivery</label>
             </settings>
         </column>
+        <actionsColumn name="actions" class="Aligent\AsyncEvents\Ui\Component\Listing\Columns\AsyncEventActions" />
     </columns>
 </listing>

--- a/view/adminhtml/ui_component/async_events_logs_trace.xml
+++ b/view/adminhtml/ui_component/async_events_logs_trace.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <argument name="data" xsi:type="array">
+        <item name="js_config" xsi:type="array">
+            <item name="provider" xsi:type="string">async_events_logs_trace.async_events_logs_trace_data_source</item>
+        </item>
+        <item name="label" xsi:type="string" translate="true">Trace Information</item>
+    </argument>
+    <settings>
+        <buttons>
+            <button name="save" class="Aligent\AsyncEvents\Block\Adminhtml\Trace\Details\ReplayButton" />
+            <button name="back" class="Aligent\AsyncEvents\Block\Adminhtml\Trace\Details\BackButton" />
+        </buttons>
+        <layout>
+            <navContainerName>left</navContainerName>
+            <type>tabs</type>
+        </layout>
+        <namespace>async_events_logs_trace</namespace>
+        <dataScope>data</dataScope>
+        <deps>
+            <dep>async_events_logs_trace.async_events_logs_trace_data_source</dep>
+        </deps>
+    </settings>
+    <dataSource name="async_events_logs_trace_data_source">
+        <argument name="data" xsi:type="array">
+            <item name="js_config" xsi:type="array">
+                <item name="component" xsi:type="string">Magento_Ui/js/form/provider</item>
+            </item>
+        </argument>
+        <settings>
+            <submitUrl path="async_events/events/retry" />
+        </settings>
+        <dataProvider class="Aligent\AsyncEvents\Ui\DataProvider\AsyncEventsTrace" name="async_events_logs_trace_data_source">
+            <settings>
+                <requestFieldName>uuid</requestFieldName>
+                <primaryFieldName>uuid</primaryFieldName>
+            </settings>
+        </dataProvider>
+    </dataSource>
+    <fieldset name="general" sortOrder="0">
+        <settings>
+            <label translate="true">Info</label>
+        </settings>
+        <field name="uuid" formElement="input">
+            <settings>
+                <elementTmpl>ui/form/element/text</elementTmpl>
+                <dataType>text</dataType>
+                <label translate="true">UUID</label>
+            </settings>
+        </field>
+    </fieldset>
+    <htmlContent name="async_events_trace_tab_view_content" sortOrder="20">
+        <block class="Aligent\AsyncEvents\Block\Adminhtml\Trace\Tab\View" name="async_events_trace_tab_view" template="Aligent_AsyncEvents::tab/view.phtml">
+            <arguments>
+                <argument name="sort_order" xsi:type="number">10</argument>
+                <argument name="tab_label" xsi:type="string" translate="true">Overview</argument>
+            </arguments>
+            <block class="Aligent\AsyncEvents\Block\Adminhtml\Trace\Tab\View\Info" name="trace_info" template="Aligent_AsyncEvents::tab/view/info.phtml" />
+        </block>
+    </htmlContent>
+</form>

--- a/view/adminhtml/ui_component/async_events_logs_trace.xml
+++ b/view/adminhtml/ui_component/async_events_logs_trace.xml
@@ -54,6 +54,12 @@
                 <label translate="true">UUID</label>
             </settings>
         </field>
+        <field name="serialized_data" formElement="textarea">
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Serialized Data</label>
+            </settings>
+        </field>
     </fieldset>
     <htmlContent name="async_events_trace_tab_view_content" sortOrder="20">
         <block class="Aligent\AsyncEvents\Block\Adminhtml\Trace\Tab\View" name="async_events_trace_tab_view" template="Aligent_AsyncEvents::tab/view.phtml">

--- a/view/adminhtml/ui_component/async_events_logs_trace.xml
+++ b/view/adminhtml/ui_component/async_events_logs_trace.xml
@@ -55,6 +55,11 @@
             </settings>
         </field>
         <field name="serialized_data" formElement="textarea">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="rows" xsi:type="number">20</item>
+                </item>
+            </argument>
             <settings>
                 <dataType>text</dataType>
                 <label translate="true">Serialized Data</label>


### PR DESCRIPTION
1. #10 Creates a detailed page to view information in detail
2. #12  Introduces replay functionality to replay any event (Dead Lettered and Successful ones)

## Listing Page
![image](https://user-images.githubusercontent.com/40108018/148366412-84f9490a-528a-4e8e-aa9a-ca4747e1a0d6.png)
A new trace button has been added to open the asynchronous event delivery in detail

## Trace Page
![image](https://user-images.githubusercontent.com/40108018/148366539-54cccf7e-d472-4aef-8ed7-6ce5ccf7360a.png)
A more detailed view including all attempted deliveries and subscription information and a replay button
