### PR TITLE
Pretty print json serialized data

### DIFF
--- a/Model/Details.php
+++ b/Model/Details.php
@@ -53,7 +53,7 @@ class Details
         $asyncEventId = $collection->getFirstItem()->getData('subscription_id');
 
         try {
-            $asyncEvent = $this->asyncEventRepository->get($asyncEventId)->getData();
+            $asyncEvent = $this->asyncEventRepository->get((int) $asyncEventId)->getData();
             $this->traceCache[$uuid] = [
                 'traces' => $traces['items'],
                 'async_event' => $asyncEvent

--- a/Ui/DataProvider/AsyncEventsTrace.php
+++ b/Ui/DataProvider/AsyncEventsTrace.php
@@ -61,10 +61,18 @@ class AsyncEventsTrace extends AbstractDataProvider
     {
         $uuid = $this->request->getParam($this->requestFieldName);
         $details = $this->traceDetails->getDetails($uuid);
+        $trace = current($details['traces']);
+
+        /**
+         * Prettify JSON by decoding and re-encoding with the JSON_PRETTY_PRINT flag
+         */
+        $prettyPrint = json_decode($trace['serialized_data'], true);
+        $prettyPrint = json_encode($prettyPrint, JSON_PRETTY_PRINT);
+        $trace['serialized_data'] = $prettyPrint;
 
         return [
             $uuid => [
-                'general' => current($details['traces'])
+                'general' => $trace
             ]
         ];
     }

--- a/view/adminhtml/ui_component/async_events_logs_trace.xml
+++ b/view/adminhtml/ui_component/async_events_logs_trace.xml
@@ -61,6 +61,7 @@
                 </item>
             </argument>
             <settings>
+                <elementTmpl>Aligent_AsyncEvents/content/json</elementTmpl>
                 <dataType>text</dataType>
                 <label translate="true">Serialized Data</label>
             </settings>

--- a/view/base/web/template/content/json.html
+++ b/view/base/web/template/content/json.html
@@ -2,7 +2,7 @@
 style="background: #f6f6f6;
     border: 1px solid #cccccc;
     color: #111111;
-    line-height: 1.5;
+    line-height: calc(20/14);
     margin: 0 0 10px;
     padding: 10px;
     font-size: 1.2rem;

--- a/view/base/web/template/content/json.html
+++ b/view/base/web/template/content/json.html
@@ -2,7 +2,7 @@
 style="background: #f6f6f6;
     border: 1px solid #cccccc;
     color: #111111;
-    line-height: 1.42857143;
+    line-height: 1.5;
     margin: 0 0 10px;
     padding: 10px;
     font-size: 1.2rem;

--- a/view/base/web/template/content/json.html
+++ b/view/base/web/template/content/json.html
@@ -1,0 +1,12 @@
+<pre data-bind="text: value"
+style="background: #f6f6f6;
+    border: 1px solid #cccccc;
+    color: #111111;
+    line-height: 1.42857143;
+    margin: 0 0 10px;
+    padding: 10px;
+    font-size: 1.2rem;
+    display: block;
+    word-wrap: break-word;"
+>
+</pre>


### PR DESCRIPTION
Resolves #17 

Open to discussion and suggestions.

A couple of points
* I've used inline css with rules copied from the luma `pre` tag css. This can probably be done in a proper way via css and adding classes but since this is such a one time use case, I doubt it's worth the effort.
* In terms of pretty printing, I wanted to do it in Knockout.js in the frontend, but there's no way to create a custom `uiElement`. ex: a json viewer knockout view model. Because of `definition.xml` (can't add custom ui components as such)
* The alternate route was doing it in the data provider. I've used the `json_encode()` directly. Normally I'd use the `\Magento\Framework\Serialize\SerializerInterface` but since I'll need the `JSON_PRETTY_PRINT` flag, I'll have to create a new concrete implementation like `PrettyPrintJson implements SerializerInterface`. DI inject that into the constructor and use it. Again feels like too much code to achieve the same thing.
