### PR TITLE
Minor maintenance work

### DIFF
--- a/Controller/Adminhtml/Events/Index.php
+++ b/Controller/Adminhtml/Events/Index.php
@@ -38,7 +38,7 @@ class Index extends Action implements HttpGetActionInterface
     {
         $resultPage = $this->resultPageFactory->create();
         $resultPage->setActiveMenu(self::MENU_ID);
-        $resultPage->getConfig()->getTitle()->prepend(__('Asynchronous Events'));
+        $resultPage->getConfig()->getTitle()->prepend(__('Asynchronous Event Subscribers'));
 
         return $resultPage;
     }

--- a/Controller/Adminhtml/Logs/Index.php
+++ b/Controller/Adminhtml/Logs/Index.php
@@ -39,7 +39,7 @@ class Index extends Action implements HttpGetActionInterface
     {
         $resultPage = $this->resultPageFactory->create();
         $resultPage->setActiveMenu(self::MENU_ID);
-        $resultPage->getConfig()->getTitle()->prepend(__('Event Logs'));
+        $resultPage->getConfig()->getTitle()->prepend(__('Asynchronous Event Logs'));
 
         return $resultPage;
     }

--- a/Model/ResourceModel/AsyncEvent/Grid/Collection.php
+++ b/Model/ResourceModel/AsyncEvent/Grid/Collection.php
@@ -4,16 +4,13 @@ declare(strict_types=1);
 
 namespace Aligent\AsyncEvents\Model\ResourceModel\AsyncEvent\Grid;
 
-use Magento\Framework\Data\Collection\Db\FetchStrategyInterface as FetchStrategy;
-use Magento\Framework\Data\Collection\EntityFactoryInterface as EntityFactory;
-use Magento\Framework\Event\ManagerInterface as EventManager;
 use Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult;
-use Psr\Log\LoggerInterface as Logger;
 
 class Collection extends SearchResult
 {
     /**
-     * Override parent method to select specific fields
+     * Override parent method to select manually add all the fields because we do not want to expose the
+     * `verification_token` field even if encrypted.
      *
      * @return $this
      */

--- a/Model/ResourceModel/AsyncEvent/Grid/Collection.php
+++ b/Model/ResourceModel/AsyncEvent/Grid/Collection.php
@@ -9,7 +9,7 @@ use Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult;
 class Collection extends SearchResult
 {
     /**
-     * Override parent method to select manually add all the fields because we do not want to expose the
+     * Override parent method to manually add all the fields because we do not want to expose the
      * `verification_token` field even if encrypted.
      *
      * @return $this

--- a/etc/queue_topology.xml
+++ b/etc/queue_topology.xml
@@ -5,7 +5,7 @@
     </exchange>
 
     <exchange name="event.failover" type="topic" connection="amqp">
-        <binding id="WebhookFailoverRetry" topic="event.retry" destinationType="queue" destination="event.failover.retry"/>
-        <binding id="WebhookKillerBinding" topic="event.retry.kill" destinationType="queue" destination="event.failover.deadletter"/>
+        <binding id="AsyncEventFailoverRetry" topic="event.retry" destinationType="queue" destination="event.failover.retry"/>
+        <binding id="AsyncEventKillerBinding" topic="event.retry.kill" destinationType="queue" destination="event.failover.deadletter"/>
     </exchange>
 </config>

--- a/view/adminhtml/templates/tab/view/info.phtml
+++ b/view/adminhtml/templates/tab/view/info.phtml
@@ -82,12 +82,11 @@ use Aligent\AsyncEvents\Block\Adminhtml\Trace\Tab\View\Info;
         <span class="title"><?= 'Traces' ?></span>
     </div>
     <div class="admin__table-wrapper">
-        <table class="admin__table-primary">
+        <table class="admin__table-primary" style="table-layout: fixed;">
             <thead>
             <tr>
                 <th><?= __('Log Id') ?></th>
                 <th><?= __('Delivery Time') ?></th>
-                <th><?= __('uuid') ?></th>
                 <th><?= __('Response') ?></th>
                 <th><?= __('Status') ?></th>
             </tr>
@@ -95,19 +94,16 @@ use Aligent\AsyncEvents\Block\Adminhtml\Trace\Tab\View\Info;
             <tbody>
             <?php foreach ($block->getLogs() as $item): ?>
                 <tr>
-                    <td style="padding: 1rem">
+                    <td>
                         <?= $item['log_id'] ?>
                     </td>
-                    <td style="padding: 1rem">
+                    <td>
                         <?= $item['created'] ?>
                     </td>
-                    <td style="padding: 1rem">
-                        <?= $item['uuid'] ?>
-                    </td>
-                    <td style="padding: 1rem">
+                    <td style="word-wrap: break-word;">
                         <?= $item['response_data'] ?>
                     </td>
-                    <td style="padding: 1rem" class="col-severity">
+                    <td class="col-severity">
                         <?= $item['success'] ?
                             '<span class="grid-severity-notice"><span>Success</span></span>' :
                             '<span class="grid-severity-critical"><span>Failed</span></span>' ?>

--- a/view/adminhtml/ui_component/async_events_events_listing.xml
+++ b/view/adminhtml/ui_component/async_events_events_listing.xml
@@ -32,19 +32,7 @@
         <columnsControls name="columns_controls"/>
         <exportButton name="export_button"/>
         <filterSearch name="fulltext"/>
-        <filters name="listing_filters">
-            <filterSelect name="store_id" provider="${ $.parentName }">
-                <settings>
-                    <options class="Magento\Store\Ui\Component\Listing\Column\Store\Options"/>
-                    <caption translate="true">All Store Views</caption>
-                    <label translate="true">Purchased From</label>
-                    <dataScope>store_id</dataScope>
-                    <imports>
-                        <link name="visible">componentType = column, index = ${ $.index }:visible</link>
-                    </imports>
-                </settings>
-            </filterSelect>
-        </filters>
+        <filters name="listing_filters" />
         <massaction name="listing_massaction">
             <action name="disable">
                 <settings>


### PR DESCRIPTION
* Rename subscribers page to `Asynchronous Event Subscribers`
* Rename async event log listing page `Asynchronous Event Logs`
* Rename exchange - queue binding
* Update some trace table to fixed so it doesn't side scroll
* Remove `UUID` field in trace table because it'll always be the same
* Remove an incorrect purchased from filter in subscriber page


### Before:
![image](https://user-images.githubusercontent.com/40108018/163412553-9794eb00-f4de-4824-9c48-f20947f085c5.png)


### After:
![image](https://user-images.githubusercontent.com/40108018/163412713-670b453f-9597-4a1f-ab5b-966a06f5ed94.png)
