### PR TITLE
Truncate response logs in listing page

### DIFF
--- a/Controller/Adminhtml/Events/Index.php
+++ b/Controller/Adminhtml/Events/Index.php
@@ -38,7 +38,7 @@ class Index extends Action implements HttpGetActionInterface
     {
         $resultPage = $this->resultPageFactory->create();
         $resultPage->setActiveMenu(self::MENU_ID);
-        $resultPage->getConfig()->getTitle()->prepend(__('Asynchronous Events'));
+        $resultPage->getConfig()->getTitle()->prepend(__('Asynchronous Event Subscribers'));
 
         return $resultPage;
     }

--- a/Controller/Adminhtml/Logs/Index.php
+++ b/Controller/Adminhtml/Logs/Index.php
@@ -39,7 +39,7 @@ class Index extends Action implements HttpGetActionInterface
     {
         $resultPage = $this->resultPageFactory->create();
         $resultPage->setActiveMenu(self::MENU_ID);
-        $resultPage->getConfig()->getTitle()->prepend(__('Event Logs'));
+        $resultPage->getConfig()->getTitle()->prepend(__('Asynchronous Event Logs'));
 
         return $resultPage;
     }

--- a/Model/ResourceModel/AsyncEvent/Grid/Collection.php
+++ b/Model/ResourceModel/AsyncEvent/Grid/Collection.php
@@ -4,16 +4,13 @@ declare(strict_types=1);
 
 namespace Aligent\AsyncEvents\Model\ResourceModel\AsyncEvent\Grid;
 
-use Magento\Framework\Data\Collection\Db\FetchStrategyInterface as FetchStrategy;
-use Magento\Framework\Data\Collection\EntityFactoryInterface as EntityFactory;
-use Magento\Framework\Event\ManagerInterface as EventManager;
 use Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult;
-use Psr\Log\LoggerInterface as Logger;
 
 class Collection extends SearchResult
 {
     /**
-     * Override parent method to select specific fields
+     * Override parent method to select manually add all the fields because we do not want to expose the
+     * `verification_token` field even if encrypted.
      *
      * @return $this
      */

--- a/Model/ResourceModel/AsyncEvent/Grid/Collection.php
+++ b/Model/ResourceModel/AsyncEvent/Grid/Collection.php
@@ -9,7 +9,7 @@ use Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult;
 class Collection extends SearchResult
 {
     /**
-     * Override parent method to select manually add all the fields because we do not want to expose the
+     * Override parent method to manually add all the fields because we do not want to expose the
      * `verification_token` field even if encrypted.
      *
      * @return $this

--- a/Model/ResourceModel/AsyncEventLog/Grid/Collection.php
+++ b/Model/ResourceModel/AsyncEventLog/Grid/Collection.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Aligent Consulting
+ * Copyright (c) Aligent Consulting (https://www.aligent.com.au)
+ */
+
+declare(strict_types=1);
+
+namespace Aligent\AsyncEvents\Model\ResourceModel\AsyncEventLog\Grid;
+
+use Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult;
+use Zend_Db_Expr;
+
+class Collection extends SearchResult
+{
+    /**
+     * @inheritDoc
+     */
+    protected function _initSelect()
+    {
+        parent::_initSelect();
+
+        $this->getSelect()
+            ->join(
+                [
+                    'aes' => $this->getTable('async_event_subscriber')
+                ],
+                'main_table.subscription_id = aes.subscription_id',
+                'event_name'
+            )->columns(
+                [
+                    'response_data' => new Zend_Db_Expr('SUBSTRING(response_data, 1, 100)')
+                ]
+            );
+
+        return $this;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -12,10 +12,18 @@
     <preference for="Aligent\AsyncEvents\Api\Data\AsyncEventSearchResultsInterface"
                 type="Aligent\AsyncEvents\Model\AsyncEventSearchResults" />
 
+    <!-- UI Component DataProviders -->
     <type name="Aligent\AsyncEvents\Model\ResourceModel\AsyncEvent\Grid\Collection">
         <arguments>
             <argument name="mainTable" xsi:type="string">async_event_subscriber</argument>
             <argument name="resourceModel" xsi:type="string">Aligent\AsyncEvents\Model\ResourceModel\AsyncEvent</argument>
+        </arguments>
+    </type>
+
+    <type name="Aligent\AsyncEvents\Model\ResourceModel\AsyncEventLog\Grid\Collection">
+        <arguments>
+            <argument name="mainTable" xsi:type="string">async_event_subscriber_log</argument>
+            <argument name="resourceModel" xsi:type="string">Aligent\AsyncEvents\Model\ResourceModel\AsyncEventLog</argument>
         </arguments>
     </type>
 
@@ -25,13 +33,13 @@
                 <item name="async_events_events_listing_data_source" xsi:type="string">
                     Aligent\AsyncEvents\Model\ResourceModel\AsyncEvent\Grid\Collection
                 </item>
-                <item name="async_events_logs_listing_data_source" xsi:type="string">Aligent\AsyncEvents\Model\ResourceModel\WebhookLogs\Grid\Collection</item>
-                <item name="async_events_logs_trace_data_source" xsi:type="string">Aligent\AsyncEvents\Model\ResourceModel\WebhookLogs\Grid\Collection</item>
+                <item name="async_events_logs_listing_data_source" xsi:type="string">Aligent\AsyncEvents\Model\ResourceModel\AsyncEventLog\Grid\Collection</item>
+                <item name="async_events_logs_trace_data_source" xsi:type="string">Aligent\AsyncEvents\Model\ResourceModel\AsyncEventLogs\Grid\Collection</item>
             </argument>
         </arguments>
     </type>
 
-    <virtualType name="Aligent\AsyncEvents\Model\ResourceModel\WebhookLogs\Grid\Collection" type="Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult">
+    <virtualType name="Aligent\AsyncEvents\Model\ResourceModel\AsyncEventLogs\Grid\Collection" type="Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult">
         <arguments>
             <argument name="mainTable" xsi:type="string">async_event_subscriber_log</argument>
             <argument name="resourceModel" xsi:type="string">Aligent\AsyncEvents\Model\ResourceModel\AsyncEventLog</argument>

--- a/etc/queue_topology.xml
+++ b/etc/queue_topology.xml
@@ -5,7 +5,7 @@
     </exchange>
 
     <exchange name="event.failover" type="topic" connection="amqp">
-        <binding id="WebhookFailoverRetry" topic="event.retry" destinationType="queue" destination="event.failover.retry"/>
-        <binding id="WebhookKillerBinding" topic="event.retry.kill" destinationType="queue" destination="event.failover.deadletter"/>
+        <binding id="AsyncEventFailoverRetry" topic="event.retry" destinationType="queue" destination="event.failover.retry"/>
+        <binding id="AsyncEventKillerBinding" topic="event.retry.kill" destinationType="queue" destination="event.failover.deadletter"/>
     </exchange>
 </config>

--- a/view/adminhtml/templates/tab/view/info.phtml
+++ b/view/adminhtml/templates/tab/view/info.phtml
@@ -82,12 +82,11 @@ use Aligent\AsyncEvents\Block\Adminhtml\Trace\Tab\View\Info;
         <span class="title"><?= 'Traces' ?></span>
     </div>
     <div class="admin__table-wrapper">
-        <table class="admin__table-primary">
+        <table class="admin__table-primary" style="table-layout: fixed;">
             <thead>
             <tr>
                 <th><?= __('Log Id') ?></th>
                 <th><?= __('Delivery Time') ?></th>
-                <th><?= __('uuid') ?></th>
                 <th><?= __('Response') ?></th>
                 <th><?= __('Status') ?></th>
             </tr>
@@ -95,19 +94,16 @@ use Aligent\AsyncEvents\Block\Adminhtml\Trace\Tab\View\Info;
             <tbody>
             <?php foreach ($block->getLogs() as $item): ?>
                 <tr>
-                    <td style="padding: 1rem">
+                    <td>
                         <?= $item['log_id'] ?>
                     </td>
-                    <td style="padding: 1rem">
+                    <td>
                         <?= $item['created'] ?>
                     </td>
-                    <td style="padding: 1rem">
-                        <?= $item['uuid'] ?>
-                    </td>
-                    <td style="padding: 1rem">
+                    <td style="word-wrap: break-word;">
                         <?= $item['response_data'] ?>
                     </td>
-                    <td style="padding: 1rem" class="col-severity">
+                    <td class="col-severity">
                         <?= $item['success'] ?
                             '<span class="grid-severity-notice"><span>Success</span></span>' :
                             '<span class="grid-severity-critical"><span>Failed</span></span>' ?>

--- a/view/adminhtml/ui_component/async_events_events_listing.xml
+++ b/view/adminhtml/ui_component/async_events_events_listing.xml
@@ -32,19 +32,7 @@
         <columnsControls name="columns_controls"/>
         <exportButton name="export_button"/>
         <filterSearch name="fulltext"/>
-        <filters name="listing_filters">
-            <filterSelect name="store_id" provider="${ $.parentName }">
-                <settings>
-                    <options class="Magento\Store\Ui\Component\Listing\Column\Store\Options"/>
-                    <caption translate="true">All Store Views</caption>
-                    <label translate="true">Purchased From</label>
-                    <dataScope>store_id</dataScope>
-                    <imports>
-                        <link name="visible">componentType = column, index = ${ $.index }:visible</link>
-                    </imports>
-                </settings>
-            </filterSelect>
-        </filters>
+        <filters name="listing_filters" />
         <massaction name="listing_massaction">
             <action name="disable">
                 <settings>

--- a/view/adminhtml/ui_component/async_events_logs_listing.xml
+++ b/view/adminhtml/ui_component/async_events_logs_listing.xml
@@ -59,10 +59,10 @@
             </settings>
         </column>
 
-        <column name="subscription_id" sortOrder="30">
+        <column name="event_name" sortOrder="30">
             <settings>
                 <filter>text</filter>
-                <label translate="true">Subscription</label>
+                <label translate="true">Asynchronous Event</label>
             </settings>
         </column>
 
@@ -79,7 +79,6 @@
 
         <column name="response_data" sortOrder="50">
             <settings>
-                <filter>text</filter>
                 <label translate="true">Response</label>
             </settings>
         </column>


### PR DESCRIPTION
Sometimes the downstream system might send responses which might be too big to view in a listing page. It's a major inconvenience when trying to debug, investigate something.

### Before:
![image](https://user-images.githubusercontent.com/40108018/163413932-1973eb5a-a6df-4928-9862-a238b050e002.png)

### After:
![image](https://user-images.githubusercontent.com/40108018/163414173-19537bd6-80f7-4088-9eb1-4044c4faba8c.png)

I've also added the asynchronous event name to be visible instead of the subscription id as it's even more convenient to have a look, filter async events

### Before:
![image](https://user-images.githubusercontent.com/40108018/163414651-b4e124d5-ef2f-4bdd-946d-04bd6477c394.png)

### After:
![image](https://user-images.githubusercontent.com/40108018/163414418-45982c1a-28a2-4781-b04b-7bfd0efdbdaf.png)
