### PR TITLE
Add configurable death/retry count

### DIFF
--- a/Model/RetryHandler.php
+++ b/Model/RetryHandler.php
@@ -54,7 +54,16 @@ class RetryHandler
      */
     private $scopeConfig;
 
-
+    /**
+     * @param SearchCriteriaBuilder $searchCriteriaBuilder
+     * @param AsyncEventRepositoryInterface $asyncEventRepository
+     * @param NotifierFactoryInterface $notifierFactory
+     * @param AsyncEventLogFactory $asyncEventLogFactory
+     * @param AsyncEventLogRepository $asyncEventLogRepository
+     * @param RetryManager $retryManager
+     * @param SerializerInterface $serializer
+     * @param ScopeConfigInterface $scopeConfig
+     */
     public function __construct(
         SearchCriteriaBuilder         $searchCriteriaBuilder,
         AsyncEventRepositoryInterface $asyncEventRepository,

--- a/Model/RetryHandler.php
+++ b/Model/RetryHandler.php
@@ -9,13 +9,12 @@ use Aligent\AsyncEvents\Helper\NotifierResult;
 use Aligent\AsyncEvents\Service\AsyncEvent\NotifierFactoryInterface;
 use Aligent\AsyncEvents\Service\AsyncEvent\RetryManager;
 use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Framework\Serialize\SerializerInterface;
 
 class RetryHandler
 {
-    const RETRY_LIMIT = 5;
-
     /**
      * @var SearchCriteriaBuilder
      */
@@ -50,16 +49,12 @@ class RetryHandler
      * @var SerializerInterface
      */
     private $serializer;
-
     /**
-     * @param SearchCriteriaBuilder $searchCriteriaBuilder
-     * @param AsyncEventRepositoryInterface $asyncEventRepository
-     * @param NotifierFactoryInterface $notifierFactory
-     * @param AsyncEventLogFactory $asyncEventLogFactory
-     * @param AsyncEventLogRepository $asyncEventLogRepository
-     * @param RetryManager $retryManager
-     * @param SerializerInterface $serializer
+     * @var ScopeConfigInterface
      */
+    private $scopeConfig;
+
+
     public function __construct(
         SearchCriteriaBuilder         $searchCriteriaBuilder,
         AsyncEventRepositoryInterface $asyncEventRepository,
@@ -67,7 +62,8 @@ class RetryHandler
         AsyncEventLogFactory          $asyncEventLogFactory,
         AsyncEventLogRepository       $asyncEventLogRepository,
         RetryManager                  $retryManager,
-        SerializerInterface           $serializer
+        SerializerInterface           $serializer,
+        ScopeConfigInterface          $scopeConfig
     ) {
         $this->asyncEventRepository = $asyncEventRepository;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
@@ -76,6 +72,7 @@ class RetryHandler
         $this->asyncEventLogRepository = $asyncEventLogRepository;
         $this->retryManager = $retryManager;
         $this->serializer = $serializer;
+        $this->scopeConfig = $scopeConfig;
     }
 
     /**
@@ -90,6 +87,7 @@ class RetryHandler
 
         $subscriptionId = (int) $subscriptionId;
         $deathCount = (int) $deathCount;
+        $retryLimit = (int) $this->scopeConfig->getValue('system/async_events/retry');
 
         $data = $this->serializer->unserialize($data);
 
@@ -110,7 +108,7 @@ class RetryHandler
             $this->log($response);
 
             if (!$response->getSuccess()) {
-                if ($deathCount < self::RETRY_LIMIT) {
+                if ($deathCount < $retryLimit) {
                     $this->retryManager->place($deathCount + 1, $subscriptionId, $data, $uuid);
                 } else {
                     $this->retryManager->kill($subscriptionId, $data);

--- a/Model/RetryHandler.php
+++ b/Model/RetryHandler.php
@@ -96,7 +96,7 @@ class RetryHandler
 
         $subscriptionId = (int) $subscriptionId;
         $deathCount = (int) $deathCount;
-        $retryLimit = (int) $this->scopeConfig->getValue('system/async_events/death_count');
+        $maxDeaths = (int) $this->scopeConfig->getValue('system/async_events/max_deaths');
 
         $data = $this->serializer->unserialize($data);
 
@@ -117,7 +117,7 @@ class RetryHandler
             $this->log($response);
 
             if (!$response->getSuccess()) {
-                if ($deathCount < $retryLimit) {
+                if ($deathCount < $maxDeaths) {
                     $this->retryManager->place($deathCount + 1, $subscriptionId, $data, $uuid);
                 } else {
                     $this->retryManager->kill($subscriptionId, $data);

--- a/Model/RetryHandler.php
+++ b/Model/RetryHandler.php
@@ -96,7 +96,7 @@ class RetryHandler
 
         $subscriptionId = (int) $subscriptionId;
         $deathCount = (int) $deathCount;
-        $retryLimit = (int) $this->scopeConfig->getValue('system/async_events/retry');
+        $retryLimit = (int) $this->scopeConfig->getValue('system/async_events/death_count');
 
         $data = $this->serializer->unserialize($data);
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <section id="system" translate="label" type="text" sortOrder="900">
+            <tab>advanced</tab>
+            <resource>Aligent_AsyncEvents::manage</resource>
+            <group id="async_events" translate="label" type="text" sortOrder="1000">
+                <label>Async Events</label>
+                <field id="retry" translate="label" type="text" sortOrder="10">
+                    <label>Retry Count</label>
+                    <validate>integer validate-not-negative-number</validate>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -7,8 +7,8 @@
             <resource>Aligent_AsyncEvents::manage</resource>
             <group id="async_events" translate="label" type="text" sortOrder="1000" showInDefault="1">
                 <label>Async Events</label>
-                <field id="retry" translate="label" type="text" sortOrder="10" showInDefault="1">
-                    <label>Retry Count</label>
+                <field id="death_count" translate="label" type="text" sortOrder="10" showInDefault="1">
+                    <label>Death Count</label>
                     <validate>integer validate-not-negative-number</validate>
                 </field>
             </group>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -2,12 +2,12 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <section id="system" translate="label" type="text" sortOrder="900">
+        <section id="system" translate="label" type="text" sortOrder="900" showInDefault="1">
             <tab>advanced</tab>
             <resource>Aligent_AsyncEvents::manage</resource>
-            <group id="async_events" translate="label" type="text" sortOrder="1000">
+            <group id="async_events" translate="label" type="text" sortOrder="1000" showInDefault="1">
                 <label>Async Events</label>
-                <field id="retry" translate="label" type="text" sortOrder="10">
+                <field id="retry" translate="label" type="text" sortOrder="10" showInDefault="1">
                     <label>Retry Count</label>
                     <validate>integer validate-not-negative-number</validate>
                 </field>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -7,8 +7,8 @@
             <resource>Aligent_AsyncEvents::manage</resource>
             <group id="async_events" translate="label" type="text" sortOrder="1000" showInDefault="1">
                 <label>Async Events</label>
-                <field id="death_count" translate="label" type="text" sortOrder="10" showInDefault="1">
-                    <label>Death Count</label>
+                <field id="max_deaths" translate="label" type="text" sortOrder="10" showInDefault="1">
+                    <label>Maximum Deaths</label>
                     <validate>integer validate-not-negative-number</validate>
                 </field>
             </group>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -4,7 +4,7 @@
     <default>
         <system>
             <async_events>
-                <death_count>5</death_count>
+                <max_deaths>5</max_deaths>
             </async_events>
         </system>
     </default>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
+    <default>
+        <system>
+            <async_events>
+                <retry>5</retry>
+            </async_events>
+        </system>
+    </default>
+</config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -4,7 +4,7 @@
     <default>
         <system>
             <async_events>
-                <retry>5</retry>
+                <death_count>5</death_count>
             </async_events>
         </system>
     </default>


### PR DESCRIPTION
**Description of the proposed changes**
Add configurable admin retry count/limit, replacing the hard-coded limit in `RetryHandler.php` 
**Screenshots (if applicable)**
![image](https://user-images.githubusercontent.com/98719916/171108580-bf1837f8-37ef-4fd7-8acb-317a57f7bd98.png)

**Time tracking**
Please use Toggl time code **eg: ALG-119: magento-async-events Code Review**