### PR TITLE
BEG-80: add subscriber log cleanup cron

### DIFF
--- a/Cron/CleanSubscriberLog.php
+++ b/Cron/CleanSubscriberLog.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Aligent\AsyncEvents\Cron;
+
+use Aligent\AsyncEvents\Model\AsyncEventCleanSubscriberLogs;
+use Psr\Log\LoggerInterface;
+
+class CleanSubscriberLog
+{
+    private $logger;
+    private $cleanSubscriberLogs;
+
+    /**
+     * @param LoggerInterface $logger
+     * @param AsyncEventCleanSubscriberLogs $cleanSubscriberLogs
+     */
+    public function __construct(LoggerInterface $logger, AsyncEventCleanSubscriberLogs $cleanSubscriberLogs)
+    {
+        $this->logger = $logger;
+        $this->cleanSubscriberLogs = $cleanSubscriberLogs;
+    }
+
+    /**
+     * @return void
+     */
+    public function execute()
+    {
+        try {
+            $this->cleanSubscriberLogs->cleanSubscriberLogs();
+        } catch (\Exception $e) {
+            $this->logger->error("Could not clean subscriber logs", ["Exception" => $e]);
+        }
+    }
+}

--- a/Model/AsyncEventCleanSubscriberLogs.php
+++ b/Model/AsyncEventCleanSubscriberLogs.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Aligent\AsyncEvents\Model;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Stdlib\DateTime;
+
+class AsyncEventCleanSubscriberLogs
+{
+    private $resourceConnection;
+    private $scopeConfig;
+    private $dateTime;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param ScopeConfigInterface $scopeConfig
+     * @param DateTime $dateTime
+     */
+    public function __construct(
+        ResourceConnection   $resourceConnection,
+        ScopeConfigInterface $scopeConfig,
+        DateTime             $dateTime
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->scopeConfig = $scopeConfig;
+        $this->dateTime = $dateTime;
+    }
+
+    /**
+     * Deletes all logs older than specified days using an SQL command
+     *
+     * @return void
+     */
+    public function cleanSubscriberLogs()
+    {
+        // check if cron is enabled or disabled in system configuration
+        $shouldRunCron = $this->scopeConfig->getValue('system/async_events/subscriber_log_cleanup_cron');
+
+        if($shouldRunCron){
+            $connection = $this->resourceConnection->getConnection(\Magento\Framework\App\ResourceConnection::DEFAULT_CONNECTION);
+
+            // retrieve amount of days for oldest log from system config
+            $timePeriodInDays = (string)$this->scopeConfig->getValue('system/async_events/subscriber_log_cron_delete_period');
+
+            // creates a date that is x amount of days in the past and checks if the log record is older than that
+            $now = $this->dateTime->formatDate(time());
+            $periodDate = $this->dateTime->formatDate(strtotime("$now -$timePeriodInDays days"));
+
+            // deletes all logs older than period date
+            $connection->delete("async_event_subscriber_log", ["created < ?" => $periodDate]);
+
+            $this->resourceConnection->closeConnection(\Magento\Framework\App\ResourceConnection::DEFAULT_CONNECTION);
+        }
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -5,18 +5,18 @@
         <section id="system" translate="label" type="text" sortOrder="900" showInDefault="1">
             <tab>advanced</tab>
             <resource>Aligent_AsyncEvents::manage</resource>
-            <group id="async_events" translate="label" type="text" sortOrder="1000" showInDefault="1" showInStore="1" showInWebsite="1">
+            <group id="async_events" translate="label" type="text" sortOrder="1000" showInDefault="1">
                 <label>Async Events</label>
-                <field id="max_deaths" translate="label" type="text" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1">
+                <field id="max_deaths" translate="label" type="text" sortOrder="10" showInDefault="1">
                     <label>Maximum Deaths</label>
                     <validate>integer validate-not-negative-number</validate>
                 </field>
-                <field id="subscriber_log_cleanup_cron" translate="label" type="select" sortOrder="20" showInDefault="1" showInStore="1" showInWebsite="1">
+                <field id="subscriber_log_cleanup_cron" translate="label" type="select" sortOrder="20" showInDefault="1">
                     <label>Subscriber Log Cleanup</label>
                     <comment>Enable or disable the subscriber log cleanup cron. </comment>
                     <source_model>Magento\Config\Model\Config\Source\Enabledisable</source_model>
                 </field>
-                <field id="subscriber_log_cron_delete_period" translate="label" type="text" sortOrder="25" showInDefault="1" showInStore="1" showInWebsite="1">
+                <field id="subscriber_log_cron_delete_period" translate="label" type="text" sortOrder="25" showInDefault="1">
                     <depends>
                         <field id="system/async_events/subscriber_log_cleanup_cron">1</field>
                     </depends>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -20,8 +20,8 @@
                     <depends>
                         <field id="system/async_events/subscriber_log_cleanup_cron">1</field>
                     </depends>
-                    <label>Oldest Subscriber Log (days)</label>
-                    <comment>Specify how old subscriber logs can get in days. Any logs older will be deleted by the cleanup cron.</comment>
+                    <label>Asynchronous Event Log Lifetime (Days)</label>
+                    <comment>Any logs older will be deleted by the cleanup cron.</comment>
                     <validate>integer validate-not-negative-number</validate>
                 </field>
             </group>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -5,10 +5,23 @@
         <section id="system" translate="label" type="text" sortOrder="900" showInDefault="1">
             <tab>advanced</tab>
             <resource>Aligent_AsyncEvents::manage</resource>
-            <group id="async_events" translate="label" type="text" sortOrder="1000" showInDefault="1">
+            <group id="async_events" translate="label" type="text" sortOrder="1000" showInDefault="1" showInStore="1" showInWebsite="1">
                 <label>Async Events</label>
-                <field id="max_deaths" translate="label" type="text" sortOrder="10" showInDefault="1">
+                <field id="max_deaths" translate="label" type="text" sortOrder="10" showInDefault="1" showInStore="1" showInWebsite="1">
                     <label>Maximum Deaths</label>
+                    <validate>integer validate-not-negative-number</validate>
+                </field>
+                <field id="subscriber_log_cleanup_cron" translate="label" type="select" sortOrder="20" showInDefault="1" showInStore="1" showInWebsite="1">
+                    <label>Subscriber Log Cleanup</label>
+                    <comment>Enable or disable the subscriber log cleanup cron. </comment>
+                    <source_model>Magento\Config\Model\Config\Source\Enabledisable</source_model>
+                </field>
+                <field id="subscriber_log_cron_delete_period" translate="label" type="text" sortOrder="25" showInDefault="1" showInStore="1" showInWebsite="1">
+                    <depends>
+                        <field id="system/async_events/subscriber_log_cleanup_cron">1</field>
+                    </depends>
+                    <label>Oldest Subscriber Log (days)</label>
+                    <comment>Specify how old subscriber logs can get in days. Any logs older will be deleted by the cleanup cron.</comment>
                     <validate>integer validate-not-negative-number</validate>
                 </field>
             </group>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -5,6 +5,8 @@
         <system>
             <async_events>
                 <max_deaths>5</max_deaths>
+                <subscriber_log_cleanup_cron>0</subscriber_log_cleanup_cron>
+                <subscriber_log_cron_delete_period>30</subscriber_log_cron_delete_period>
             </async_events>
         </system>
     </default>

--- a/etc/cron_groups.xml
+++ b/etc/cron_groups.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/cron_groups.xsd">
+    <group id="async_events">
+        <schedule_generate_every>1</schedule_generate_every>
+        <schedule_ahead_for>4</schedule_ahead_for>
+        <schedule_lifetime>2</schedule_lifetime>
+        <history_cleanup_every>10</history_cleanup_every>
+        <history_success_lifetime>60</history_success_lifetime>
+        <history_failure_lifetime>600</history_failure_lifetime>
+        <use_separate_process>1</use_separate_process>
+    </group>
+</config>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
+    <group id="async_events">
+        <job name="aligent_asyncevents_cron_cleansubscriberlog" instance="Aligent\AsyncEvents\Cron\CleanSubscriberLog" method="execute">
+            <schedule>0 1 * * *</schedule>
+        </job>
+    </group>
+</config>


### PR DESCRIPTION
### Description
- We need a cron job that runs periodically and deletes old records from the async_event_subscriber_log table. 
- The setting of how old should be configurable via the admin (older than 10 days, 20 days, 30 days etc).
- For now we can say the cron runs once per day.
- The cron should also be able to be turned on or off.
### Screenshots
![Recording 2022-06-08 at 14 11 24](https://user-images.githubusercontent.com/98719916/172533242-c49c89b0-bba0-4473-b92f-d30e5220b847.gif)
### Notes to reviewers
Jira: https://aligent.atlassian.net/browse/BEG-80
### Time tracking
Please use `BEG-80: magento-async-events Code Review`