### PR TITLE
Lucene Query Syntax

### DIFF
--- a/Model/Indexer/LuceneSearch.php
+++ b/Model/Indexer/LuceneSearch.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Aligent Consulting
+ * Copyright (c) Aligent Consulting (https://www.aligent.com.au)
+ */
+
+declare(strict_types=1);
+
+namespace Aligent\AsyncEvents\Model\Indexer;
+
+use Exception;
+use Magento\Elasticsearch\SearchAdapter\ConnectionManager;
+use Magento\Framework\Api\FilterBuilder;
+use Magento\Framework\View\Element\UiComponent\ContextInterface;
+use Magento\Framework\View\Element\UiComponentFactory;
+use Magento\Ui\Component\Filters\FilterModifier;
+use Magento\Ui\Component\Filters\Type\Search;
+
+class LuceneSearch extends Search
+{
+
+    /**
+     * @var ConnectionManager
+     */
+    private $connectionManager;
+
+    public function __construct(
+        ContextInterface $context,
+        UiComponentFactory $uiComponentFactory,
+        FilterBuilder $filterBuilder,
+        FilterModifier $filterModifier,
+        ConnectionManager $connectionManager,
+        array $components = [],
+        array $data = []
+    ) {
+        parent::__construct($context, $uiComponentFactory, $filterBuilder, $filterModifier, $components, $data);
+        $this->connectionManager = $connectionManager;
+    }
+
+    /**
+     * @return void
+     */
+    public function prepare()
+    {
+        $client = $this->connectionManager->getConnection();
+        $value = $this->getContext()->getRequestParam('search');
+
+        try {
+            $rawResponse = $client->query(
+                [
+                    'index' => 'magento2_async_event_*',
+                    'q' => $value
+                ]
+            );
+
+            $rawDocuments = $rawResponse['hits']['hits'] ?? [];
+            $asyncEventIds = [];
+
+            foreach ($rawDocuments as $document) {
+                $asyncEventIds[] = $document['_id'];
+            }
+
+            if (!empty($asyncEventIds)) {
+                $filter = $this->filterBuilder->setConditionType('in')
+                    ->setField('log_id')
+                    ->setValue($asyncEventIds)
+                    ->create();
+
+                $this->getContext()->getDataProvider()->addFilter($filter);
+            }
+        } catch (Exception $exception) {
+            parent::prepare();
+        }
+    }
+}

--- a/Model/Indexer/LuceneSearch.php
+++ b/Model/Indexer/LuceneSearch.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * Aligent Consulting
- * Copyright (c) Aligent Consulting (https://www.aligent.com.au)
- */
-
 declare(strict_types=1);
 
 namespace Aligent\AsyncEvents\Model\Indexer;
@@ -25,6 +20,15 @@ class LuceneSearch extends Search
      */
     private $connectionManager;
 
+    /**
+     * @param ContextInterface $context
+     * @param UiComponentFactory $uiComponentFactory
+     * @param FilterBuilder $filterBuilder
+     * @param FilterModifier $filterModifier
+     * @param ConnectionManager $connectionManager
+     * @param array $components
+     * @param array $data
+     */
     public function __construct(
         ContextInterface $context,
         UiComponentFactory $uiComponentFactory,
@@ -55,21 +59,18 @@ class LuceneSearch extends Search
             );
 
             $rawDocuments = $rawResponse['hits']['hits'] ?? [];
-            $asyncEventIds = [];
-
-            foreach ($rawDocuments as $document) {
-                $asyncEventIds[] = $document['_id'];
-            }
+            $asyncEventIds = array_column($rawDocuments, '_id');
 
             if (!empty($asyncEventIds)) {
                 $filter = $this->filterBuilder->setConditionType('in')
-                    ->setField('log_id')
+                    ->setField($this->getName())
                     ->setValue($asyncEventIds)
                     ->create();
 
                 $this->getContext()->getDataProvider()->addFilter($filter);
             }
         } catch (Exception $exception) {
+            // Fallback to default filter search
             parent::prepare();
         }
     }

--- a/view/adminhtml/ui_component/async_events_logs_listing.xml
+++ b/view/adminhtml/ui_component/async_events_logs_listing.xml
@@ -33,6 +33,7 @@
         <bookmark name="bookmarks"/>
         <columnsControls name="columns_controls"/>
         <filters name="listing_filters"/>
+        <filterSearch name="fulltext" class="\Aligent\AsyncEvents\Model\Indexer\LuceneSearch"/>
         <exportButton name="export_button"/>
         <paging name="listing_paging"/>
     </listingToolbar>

--- a/view/adminhtml/ui_component/async_events_logs_listing.xml
+++ b/view/adminhtml/ui_component/async_events_logs_listing.xml
@@ -33,7 +33,7 @@
         <bookmark name="bookmarks"/>
         <columnsControls name="columns_controls"/>
         <filters name="listing_filters"/>
-        <filterSearch name="fulltext" class="\Aligent\AsyncEvents\Model\Indexer\LuceneSearch"/>
+        <filterSearch name="log_id" class="\Aligent\AsyncEvents\Model\Indexer\LuceneSearch"/>
         <exportButton name="export_button"/>
         <paging name="listing_paging"/>
     </listingToolbar>


### PR DESCRIPTION
Closes #30 :tada: 

Stiches the indexing working together.

Elasticsearch natively supports querying using the [Lucene query string](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html) syntax. All indexable fields available in the event payload are indexed and searchable.

### Some examples

Find all sales orders where customer email is gmail
`event_name: sales.order.* AND data.data.customer_email: "*@gmail.com"`

Find using specific order id in payload
`event_name: sales.order.created AND data.data.increment_id: *00017`

![image](https://user-images.githubusercontent.com/40108018/187686589-5fb1cbd7-677c-4c55-b185-2d5dd123b87f.png)
