### PR TITLE
Fix index prefix config not respected in lucene search query

### DIFF
--- a/Model/Indexer/LuceneSearch.php
+++ b/Model/Indexer/LuceneSearch.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Aligent\AsyncEvents\Model\Indexer;
 
 use Exception;
+use Magento\Elasticsearch\Model\Config;
 use Magento\Elasticsearch\SearchAdapter\ConnectionManager;
 use Magento\Framework\Api\FilterBuilder;
 use Magento\Framework\View\Element\UiComponent\ContextInterface;
@@ -20,6 +21,7 @@ class LuceneSearch extends Search
      * @param FilterBuilder $filterBuilder
      * @param FilterModifier $filterModifier
      * @param ConnectionManager $connectionManager
+     * @param Config $config
      * @param array $components
      * @param array $data
      */
@@ -29,6 +31,7 @@ class LuceneSearch extends Search
         FilterBuilder $filterBuilder,
         FilterModifier $filterModifier,
         private readonly ConnectionManager $connectionManager,
+        private readonly Config $config,
         array $components = [],
         array $data = []
     ) {
@@ -48,11 +51,12 @@ class LuceneSearch extends Search
     {
         $client = $this->connectionManager->getConnection();
         $value = $this->getContext()->getRequestParam('search');
+        $indexPrefix = $this->config->getIndexPrefix();
 
         try {
             $rawResponse = $client->query(
                 [
-                    'index' => 'magento2_async_event_*',
+                    'index' => $indexPrefix . '_async_event_*',
                     'q' => $value
                 ]
             );


### PR DESCRIPTION
`BEG-93`

There's a Magento configuration available which is used to set an prefixes for indices in Elasticsearch. In local environments this is usually defaulted to `magento2`. However, in cloud environments it is possible that it could be different.

Currently the prefix is not considered when querying Elasticsearch for documents which results in empty result set.

This PR fixes the assumption that an index prefix is always `magento2_async_event_*`

Here's an example project on a staging environment.

![image](https://user-images.githubusercontent.com/40108018/194203193-16b27565-59a7-4817-ad90-3521529c968b.png)

Currently the raw request to Elasticsearch looks something like

![image](https://user-images.githubusercontent.com/40108018/194203693-0cd577d9-b74e-4196-94a3-a1bd206c4c38.png)

and upon fixing the index prefix, results are correctly returned

![image](https://user-images.githubusercontent.com/40108018/194203901-fac04ca4-a454-4a19-8a8d-a14101593d51.png)
