### PR TITLE
Move plugin to appropriate function

### DIFF
--- a/Plugin/MapStringScopeToInt.php
+++ b/Plugin/MapStringScopeToInt.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
 
 namespace Aligent\AsyncEvents\Plugin;
 
-use Magento\Search\Model\ResourceModel\SynonymReader;
+use Magento\Elasticsearch\Model\Adapter\Index\BuilderInterface;
 
-class MapStringScopeIdToInt
+class MapStringScopeToInt
 {
     /**
      * Remap string to int
@@ -21,17 +21,16 @@ class MapStringScopeIdToInt
      * about stemming and synonyms as we are literally just using it for the Lucene Query Syntax we can safely ignore
      * this and remap and provide a fake store view id of 0.
      *
-     * @see vendor/magento/module-elasticsearch/Model/Adapter/Index/Builder.php:63
-     * @param SynonymReader $subject
-     * @param int|string $storeViewId
+     * @param BuilderInterface $subject
+     * @param int $storeId
      * @return array
      */
-    public function beforeGetAllSynonymsForStoreViewId(SynonymReader $subject, $storeViewId): array
+    public function beforeSetStoreId(BuilderInterface $subject, $storeId): array
     {
-        if (!is_numeric($storeViewId) && is_string($storeViewId)) {
-            $storeViewId = 0;
+        if (!is_numeric($storeId) && is_string($storeId)) {
+            $storeId = 0;
         }
 
-        return [$storeViewId];
+        return [$storeId];
     }
 }

--- a/Plugin/MapStringScopeToInt.php
+++ b/Plugin/MapStringScopeToInt.php
@@ -22,7 +22,7 @@ class MapStringScopeToInt
      * this and remap and provide a fake store view id of 0.
      *
      * @param BuilderInterface $subject
-     * @param int $storeId
+     * @param int|string $storeId
      * @return array
      */
     public function beforeSetStoreId(BuilderInterface $subject, $storeId): array

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -123,8 +123,9 @@
         <plugin name="add_entity_type_context"
                 type="Aligent\AsyncEvents\Plugin\AddEntityTypeContext"/>
     </type>
-    <type name="Magento\Search\Model\ResourceModel\SynonymReader">
-        <plugin name="map_string_scope_id_to_int"
-                type="Aligent\AsyncEvents\Plugin\MapStringScopeIdToInt"/>
+
+    <type name="Magento\Elasticsearch\Model\Adapter\Index\BuilderInterface">
+        <plugin name="map_string_scope_to_int"
+                type="Aligent\AsyncEvents\Plugin\MapStringScopeToInt"/>
     </type>
 </config>


### PR DESCRIPTION
#35 does not actually resolve the issue it is supposed to fix. This is because a generated plugin has the same function signature as the function it is plugging into.

This has been resolved by using a more appropriate function to plugin into.