### PR TITLE
Increase search result page size

### DIFF
--- a/Model/Indexer/LuceneSearch.php
+++ b/Model/Indexer/LuceneSearch.php
@@ -57,7 +57,10 @@ class LuceneSearch extends Search
             $rawResponse = $client->query(
                 [
                     'index' => $indexPrefix . '_async_event_*',
-                    'q' => $value
+                    'q' => $value,
+                    // the default page size is 10. The highest limit is 10000. If we want to traverse further, we will
+                    // have to use the search after parameter. There are no plans to implement this right now.
+                    'size' => 10000
                 ]
             );
 


### PR DESCRIPTION
Currently the search request to Elasticsearch/Opensearch only provides the Lucene query. This works fine and returns results. However the search's default result set size is 10. This is too low as it can sometimes render the searching useless if you're not able to export a list of logs as you're expecting.

![image](https://user-images.githubusercontent.com/40108018/196829706-69e0e253-5719-49b6-9cbc-286a6854061c.png)

There is a size parameter we can use to increase the size of the result set and the upper limit is `10,000`

https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#paginate-search-results

> By default, you cannot use from and size to page through more than 10,000 hits. This limit is a safeguard set by the [index.max_result_window](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-max-result-window) index setting. If you need to page through more than 10,000 hits, use the [search_after](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after) parameter instead.

Implementing the search after parameter requires some state and there are no plans to do that as of right now.

This PR bumps the limit up to 10,000 and if there is a need to paginated it could likely be done with timestamps as a filter as the `created` date time is indexed.

![image](https://user-images.githubusercontent.com/40108018/196829956-ef4e3f53-9534-4fbb-9924-e68b599946d7.png)


