### PR TITLE
Update incorrect way of setting index structure

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -94,7 +94,6 @@
     <type name="Aligent\AsyncEvents\Model\Indexer\AsyncEventSubscriber">
         <arguments>
             <argument name="dimensionProvider" xsi:type="object" shared="false">\Aligent\AsyncEvents\Model\Indexer\AsyncEventDimensionProvider</argument>
-            <argument name="indexStructure" xsi:type="object" shared="false">\Aligent\AsyncEvents\Model\Indexer\IndexStructure</argument>
         </arguments>
     </type>
 

--- a/etc/indexer.xml
+++ b/etc/indexer.xml
@@ -4,5 +4,6 @@
     <indexer id="async_event" view_id="async_event" class="Aligent\AsyncEvents\Model\Indexer\AsyncEventSubscriber">
         <title>Asynchronous Events</title>
         <description>Index asynchronous event dispatches</description>
+        <structure class="\Aligent\AsyncEvents\Model\Indexer\IndexStructure"/>
     </indexer>
 </config>


### PR DESCRIPTION
I just realised the proper way to change the index structure on an index handler is via the `indexer.xml` and not the `di.xml`.

Noticed this when running `bin/magento indexer:reindex async_event` would error out because core explicitly disallows this

```php
// \Magento\Indexer\Model\Indexer.php

  /**
   * Return indexer action instance
   *
   * @return ActionInterface
   * @throws \InvalidArgumentException
   */
  protected function getActionInstance()
  {
      return $this->actionFactory->create(
          $this->getActionClass(),
          [
              'indexStructure' => $this->getStructureInstance(), // returns null if not defined in `indexer.xml`
              'data' => $this->getData(),
          ]
      );
  }

  /**
   * Return indexer structure instance
   *
   * @return IndexStructureInterface
   */
  protected function getStructureInstance()
  {
      if (!$this->getData('structure')) {
          return null;
      }
      return $this->structureFactory->create($this->getData('structure'));
  }
```

