### PR TITLE
Update redirect URL and Lucene search support

### DIFF
--- a/Controller/Adminhtml/Events/Retry.php
+++ b/Controller/Adminhtml/Events/Retry.php
@@ -57,6 +57,6 @@ class Retry extends Action implements HttpPostActionInterface
             $data['uuid']
         );
 
-        $this->_redirect($this->_redirect->getRefererUrl());
+        $this->_redirect('*/logs/trace/uuid/' . $data['uuid'], ['_current' => true]);
     }
 }

--- a/view/adminhtml/ui_component/async_events_logs_listing.xml
+++ b/view/adminhtml/ui_component/async_events_logs_listing.xml
@@ -33,7 +33,11 @@
         <bookmark name="bookmarks"/>
         <columnsControls name="columns_controls"/>
         <filters name="listing_filters"/>
-        <filterSearch name="log_id" class="\Aligent\AsyncEvents\Model\Indexer\LuceneSearch"/>
+        <filterSearch name="log_id" class="\Aligent\AsyncEvents\Model\Indexer\LuceneSearch">
+            <settings>
+                <placeholder>Search using Lucene Query Syntax</placeholder>
+            </settings>
+        </filterSearch>
         <exportButton name="export_button"/>
         <paging name="listing_paging"/>
     </listingToolbar>


### PR DESCRIPTION
Update the redirect url parameter so when the base URL and base media URL in the config are different (likely in PWA setups) the redirect actually works instead of 404.