### PR TITLE
Add new acl permissions

### DIFF
--- a/Controller/Adminhtml/Events/Index.php
+++ b/Controller/Adminhtml/Events/Index.php
@@ -14,6 +14,8 @@ class Index extends Action implements HttpGetActionInterface
 {
     private const MENU_ID = 'Aligent_AsyncEvents::index';
 
+    public const ADMIN_RESOURCE = 'Aligent_AsyncEvents::async_events_view';
+
     /**
      * @param Context $context
      * @param PageFactory $resultPageFactory

--- a/Controller/Adminhtml/Events/MassDisable.php
+++ b/Controller/Adminhtml/Events/MassDisable.php
@@ -18,6 +18,8 @@ use Magento\Framework\App\Action\HttpPostActionInterface;
 
 class MassDisable extends Action implements HttpPostActionInterface
 {
+    public const ADMIN_RESOURCE = 'Aligent_AsyncEvents::async_events_save';
+
     /**
      * @param Context $context
      * @param Filter $filter

--- a/Controller/Adminhtml/Events/MassEnable.php
+++ b/Controller/Adminhtml/Events/MassEnable.php
@@ -18,6 +18,8 @@ use Magento\Ui\Component\MassAction\Filter;
 
 class MassEnable extends Action implements HttpPostActionInterface
 {
+    public const ADMIN_RESOURCE = 'Aligent_AsyncEvents::async_events_save';
+
     /**
      * @param Context $context
      * @param Filter $filter

--- a/Controller/Adminhtml/Events/Replay.php
+++ b/Controller/Adminhtml/Events/Replay.php
@@ -12,7 +12,7 @@ use Magento\Backend\App\Action;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\View\Result\PageFactory;
 
-class Retry extends Action implements HttpPostActionInterface
+class Replay extends Action implements HttpPostActionInterface
 {
     public const ADMIN_RESOURCE = 'Aligent_AsyncEvents::async_events_logs_replay';
 

--- a/Controller/Adminhtml/Events/Retry.php
+++ b/Controller/Adminhtml/Events/Retry.php
@@ -14,6 +14,8 @@ use Magento\Framework\View\Result\PageFactory;
 
 class Retry extends Action implements HttpPostActionInterface
 {
+    public const ADMIN_RESOURCE = 'Aligent_AsyncEvents::async_events_logs_replay';
+
     /**
      * Retry Constructor
      *

--- a/Controller/Adminhtml/Logs/Index.php
+++ b/Controller/Adminhtml/Logs/Index.php
@@ -14,6 +14,8 @@ class Index extends Action implements HttpGetActionInterface
 {
     private const MENU_ID = 'Aligent_AsyncEvents::logs';
 
+    public const ADMIN_RESOURCE = 'Aligent_AsyncEvents::async_events_logs_list';
+
     /**
      * @param Context $context
      * @param PageFactory $resultPageFactory

--- a/Controller/Adminhtml/Logs/Trace.php
+++ b/Controller/Adminhtml/Logs/Trace.php
@@ -16,6 +16,8 @@ class Trace extends Action implements HttpGetActionInterface
 {
     public const MENU_ID = 'Aligent_AsyncEvents::logs';
 
+    public const ADMIN_RESOURCE = 'Aligent_AsyncEvents::async_events_logs_trace';
+
     /**
      * @param Context $context
      * @param PageFactory $resultPageFactory

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -4,8 +4,17 @@
     <acl>
         <resources>
             <resource id="Magento_Backend::admin">
-                <resource id="Aligent_AsyncEvents::manage" title="Manage Asynchronous Events" translate="title"
-                          sortOrder="10"/>
+                <resource id="Aligent_AsyncEvents::manage" title="Asynchronous Events" translate="title"
+                          sortOrder="10">
+                    <resource id="Aligent_AsyncEvents::async_events_view" title="View" translate="title"/>
+                    <resource id="Aligent_AsyncEvents::async_events_get" title="Get" translate="title"/>
+                    <resource id="Aligent_AsyncEvents::async_events_save" title="Save" translate="title"/>
+                    <resource id="Aligent_AsyncEvents::async_events_logs" title="Logs" translate="title">
+                        <resource id="Aligent_AsyncEvents::async_events_logs_list" title="View" translate="title" />
+                        <resource id="Aligent_AsyncEvents::async_events_logs_trace" title="Trace" translate="title" />
+                        <resource id="Aligent_AsyncEvents::async_events_logs_replay" title="Replay" translate="title" />
+                    </resource>
+                </resource>
             </resource>
         </resources>
     </acl>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -5,14 +5,14 @@
         <add id="Aligent_AsyncEvents::integrations" title="Asynchronous Events" translate="title"
              module="Aligent_AsyncEvents"
              parent="Magento_Backend::stores" sortOrder="50" dependsOnModule="Aligent_AsyncEvents"
-             resource="Aligent_AsyncEvents::manage"/>
+             resource="Aligent_AsyncEvents::async_events_view"/>
 
         <add id="Aligent_AsyncEvents::index" title="Subscribers" translate="title" module="Aligent_AsyncEvents"
              parent="Aligent_AsyncEvents::integrations" sortOrder="10" dependsOnModule="Aligent_AsyncEvents"
-             action="async_events/events" resource="Aligent_AsyncEvents::manage"/>
+             action="async_events/events" resource="Aligent_AsyncEvents::async_events_view"/>
 
         <add id="Aligent_AsyncEvents::logs" title="Logs" translate="title" module="Aligent_AsyncEvents"
              parent="Aligent_AsyncEvents::integrations" sortOrder="10" dependsOnModule="Aligent_AsyncEvents"
-             action="async_events/logs" resource="Aligent_AsyncEvents::manage"/>
+             action="async_events/logs" resource="Aligent_AsyncEvents::async_events_logs"/>
     </menu>
 </config>

--- a/view/adminhtml/ui_component/async_events_logs_trace.xml
+++ b/view/adminhtml/ui_component/async_events_logs_trace.xml
@@ -35,7 +35,7 @@
             </item>
         </argument>
         <settings>
-            <submitUrl path="async_events/events/retry"/>
+            <submitUrl path="async_events/events/replay"/>
         </settings>
         <dataProvider class="Aligent\AsyncEvents\Ui\DataProvider\AsyncEventsTrace"
                       name="async_events_logs_trace_data_source">


### PR DESCRIPTION
Introduces new permissions to manage asynchronous events. This provides more granular control over admin users being able to view / trace / replay logs and update subscriber status.

![image](https://user-images.githubusercontent.com/40108018/209891056-4737efd7-9399-4567-adea-8a8aad9db748.png)


To Do:
- [ ] Integrate new acl resources with `webapi.xml` confirming if there are breaking changes.