### PR TITLE
Limit integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,8 +9,9 @@ jobs:
 
   integration-test:
     runs-on:  "ubuntu-latest"
+    
     # Only run integration tests on feature branches. Simple documentation updates, formatting can be ignored
-    if: contains(github.ref, "feature")
+    if: contains(github.ref, 'feature')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,6 +9,8 @@ jobs:
 
   integration-test:
     runs-on:  "ubuntu-latest"
+    # Only run integration tests on feature branches. Simple documentation updates, formatting can be ignored
+    if: contains(github.ref, "feature")
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
In the scenario where only minor README changes or code changes that do not introduce significant features skip running integration tests.