### PR TITLE
Conditionally run workflows

### DIFF
--- a/.github/workflows/api-functional-tests.yml
+++ b/.github/workflows/api-functional-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on:  "ubuntu-latest"
 
     # Only run api tests on feature branches. Simple documentation updates, formatting can be ignored
-#    if: contains(github.ref, 'feature')
+    if: contains(github.head_ref, 'feature')
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on:  "ubuntu-latest"
 
     # Only run integration tests on feature branches. Simple documentation updates, formatting can be ignored
-#    if: contains(github.ref, 'feature')
+    if: contains(github.head_ref, 'feature')
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
Previously the condition was defined with `github.ref`. Apparently this differs on the type of trigger. For pull request triggers, this is whatever the full form ref of the merge that happens in the action.

This meant that the jobs were getting skipped even if it had `feature` in the branch name.

![image](https://user-images.githubusercontent.com/40108018/210906692-2a0fe1c9-7f3b-4707-9e0a-126d6bebd14e.png)

This is fixed by using a different github context variable called `github.head_ref`.

Hopefully, the jobs are skipped for this PR as it doesn't need to run integration / api tests for this.