### PR TITLE
Reduce Lucene query page size

### DIFF
--- a/Model/Indexer/LuceneSearch.php
+++ b/Model/Indexer/LuceneSearch.php
@@ -66,7 +66,7 @@ class LuceneSearch extends Search
                     'q' => $value,
                     // the default page size is 10. The highest limit is 10000. If we want to traverse further, we will
                     // have to use the search after parameter. There are no plans to implement this right now.
-                    'size' => 10000
+                    'size' => 100
                 ]
             );
 


### PR DESCRIPTION
Using the highest limit was not a smart idea. It causes memory exhaustion when PHP tries to deserialize the response. I've lowered it to 100 for now. In the future, this should somehow be tied to the pagination UI component's state.