### PR TITLE
Scope async events by store ID

### DIFF
--- a/.github/workflows/api-functional-tests.yml
+++ b/.github/workflows/api-functional-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        magento: ["magento/project-community-edition:>=2.4.4 <2.4.5", "magento/project-community-edition:>=2.4.5 <2.4.6"]
+        magento: ["magento/project-community-edition:>=2.4.4 <2.4.5", "magento/project-community-edition:>=2.4.5 <2.4.6", "magento/project-community-edition:>=2.4.6 <2.4.7"]
         include:
           - magento: magento/project-community-edition:>=2.4.4 <2.4.5
             php: 8.1
@@ -33,6 +33,15 @@ jobs:
             rabbitmq: "rabbitmq:3.9-management"
             redis: "redis:6.2"
             varnish: "varnish:7.0"
+            nginx: "nginx:1.18"
+          - magento: magento/project-community-edition:>=2.4.6 <2.4.7
+            php: 8.1
+            composer: 2
+            mysql: "mysql:8.0"
+            elasticsearch: "elasticsearch:7.17.9"
+            rabbitmq: "rabbitmq:3.9-management"
+            redis: "redis:7.0"
+            varnish: "varnish:7.1"
             nginx: "nginx:1.18"
 
     services:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        magento: ["magento/project-community-edition:>=2.4.4 <2.4.5", "magento/project-community-edition:>=2.4.5 <2.4.6"]
+        magento: ["magento/project-community-edition:>=2.4.4 <2.4.5", "magento/project-community-edition:>=2.4.5 <2.4.6", "magento/project-community-edition:>=2.4.6 <2.4.7"]
         include:
           - magento: magento/project-community-edition:>=2.4.4 <2.4.5
             php: 8.1
@@ -33,6 +33,15 @@ jobs:
             rabbitmq: "rabbitmq:3.9-management"
             redis: "redis:6.2"
             varnish: "varnish:7.0"
+            nginx: "nginx:1.18"
+          - magento: magento/project-community-edition:>=2.4.6 <2.4.7
+            php: 8.1
+            composer: 2
+            mysql: "mysql:8.0"
+            elasticsearch: "elasticsearch:7.17.9"
+            rabbitmq: "rabbitmq:3.9-management"
+            redis: "redis:7.0"
+            varnish: "varnish:7.1"
             nginx: "nginx:1.18"
 
     services:

--- a/Api/Data/AsyncEventDisplayInterface.php
+++ b/Api/Data/AsyncEventDisplayInterface.php
@@ -40,4 +40,19 @@ interface AsyncEventDisplayInterface
      * @return string
      */
     public function getSubscribedAt(): string;
+
+    /**
+     * Getter for store id
+     *
+     * @return int
+     */
+    public function getStoreId(): int;
+
+    /**
+     * Setter for store id
+     *
+     * @param int $storeId
+     * @return void
+     */
+    public function setStoreId(int $storeId): void;
 }

--- a/Api/Data/AsyncEventInterface.php
+++ b/Api/Data/AsyncEventInterface.php
@@ -114,4 +114,19 @@ interface AsyncEventInterface
      * @return void
      */
     public function setMetadata(string $metadata): void;
+
+    /**
+     * Getter for store id
+     *
+     * @return int
+     */
+    public function getStoreId(): int;
+
+    /**
+     * Setter for store id
+     *
+     * @param int $storeId
+     * @return void
+     */
+    public function setStoreId(int $storeId): void;
 }

--- a/Model/AsyncEvent.php
+++ b/Model/AsyncEvent.php
@@ -134,4 +134,20 @@ class AsyncEvent extends AbstractExtensibleModel implements AsyncEventInterface,
     {
         $this->setData('metadata', $metadata);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStoreId(): int
+    {
+        return (int) $this->getData('store_id');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setStoreId(int $storeId): void
+    {
+        $this->setData('store_id', $storeId);
+    }
 }

--- a/Model/AsyncEventTriggerHandler.php
+++ b/Model/AsyncEventTriggerHandler.php
@@ -49,6 +49,7 @@ class AsyncEventTriggerHandler
             // In a future major version this will change to a schema type e.g: AsyncEventMessageInterface
             $eventName = $queueMessage[0];
             $output = $this->json->unserialize($queueMessage[1]);
+            $storeId = (int) ($queueMessage[2] ?? 0);
 
             $configData = $this->asyncEventConfig->get($eventName);
             $serviceClassName = $configData['class'];
@@ -65,7 +66,7 @@ class AsyncEventTriggerHandler
                 $serviceMethodName
             );
 
-            $this->dispatcher->dispatch($eventName, $outputData);
+            $this->dispatcher->dispatch($eventName, $outputData, $storeId);
         } catch (Exception $exception) {
             $this->logger->critical(
                 __('Error when processing %async_event async event', [

--- a/Service/AsyncEvent/EventDispatcher.php
+++ b/Service/AsyncEvent/EventDispatcher.php
@@ -37,19 +37,24 @@ class EventDispatcher
     }
 
     /**
-     * Dispatch an asynchronous event to all subscribers
+     * Dispatch an asynchronous event to scoped subscribers
      *
      * @param string $eventName
      * @param mixed $output
+     * @param int $storeId
      * @return void
      */
-    public function dispatch(string $eventName, mixed $output): void
+    public function dispatch(string $eventName, mixed $output, int $storeId = 0): void
     {
-        $searchCriteria = $this->searchCriteriaBuilder
+        $searchCriteriaBuilder = $this->searchCriteriaBuilder
             ->addFilter('status', 1)
-            ->addFilter('event_name', $eventName)
-            ->create();
+            ->addFilter('event_name', $eventName);
 
+        if ($storeId !== 0) {
+            $searchCriteriaBuilder->addFilter('store_id', $storeId);
+        }
+
+        $searchCriteria = $searchCriteriaBuilder->create();
         $asyncEvents = $this->asyncEventRepository->getList($searchCriteria)->getItems();
 
         /** @var AsyncEvent $asyncEvent */

--- a/Test/Api/AsyncEventRepositoryTest.php
+++ b/Test/Api/AsyncEventRepositoryTest.php
@@ -33,6 +33,7 @@ class AsyncEventRepositoryTest extends WebapiAbstract
         $this->assertArrayHasKey('recipient_url', $response);
         $this->assertArrayHasKey('status', $response);
         $this->assertArrayHasKey('subscribed_at', $response);
+        $this->assertArrayHasKey('store_id', $response);
 
         // Make sure that the verification token is not exposed even if it is encrypted.
         $this->assertArrayNotHasKey('verification_token', $response);
@@ -62,6 +63,7 @@ class AsyncEventRepositoryTest extends WebapiAbstract
         $this->assertArrayHasKey('recipient_url', $response['items'][0]);
         $this->assertArrayHasKey('status', $response['items'][0]);
         $this->assertArrayHasKey('subscribed_at', $response['items'][0]);
+        $this->assertArrayHasKey('store_id', $response['items'][0]);
 
         // Make sure that the verification token is not exposed even if it is encrypted.
         $this->assertArrayNotHasKey('verification_token', $response['items'][0]);

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -12,6 +12,8 @@
         <column name="modified" xsi:type="datetime" on_update="true"/>
         <column name="metadata" xsi:type="text" nullable="false"
                 comment="Extra information for instantiating notifiers"/>
+        <column xsi:type="smallint" name="store_id" unsigned="true" nullable="false" identity="false"
+                default="0" comment="Store ID"/>
 
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="subscription_id"/>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -8,7 +8,8 @@
             "status": true,
             "subscribed_at": true,
             "modified": true,
-            "metadata": true
+            "metadata": true,
+            "store_id": true
         },
         "constraint": {
             "PRIMARY": true


### PR DESCRIPTION
Asynchronous event subscriptions can be scoped by store id now. This means a single event can be subscribed to one or a select few brands/stores. A store id of `0` is special which is unscoped. 