### PR TITLE
:bug: Prevent adapter from connecting to search

### DIFF
--- a/Model/Indexer/LuceneSearch.php
+++ b/Model/Indexer/LuceneSearch.php
@@ -54,15 +54,15 @@ class LuceneSearch extends Search
     {
         $value = $this->getContext()->getRequestParam('search');
 
+        if (empty($value)) {
+            return;
+        }
+
         if ($this->asyncEventsConfig->isIndexingEnabled()) {
             $client = $this->connectionManager->getConnection();
             $indexPrefix = $this->config->getIndexPrefix();
             $filter = $this->filterBuilder->setConditionType('in')
                 ->setField($this->getName());
-
-            if ($value === "") {
-                return;
-            }
 
             try {
                 $rawResponse = $client->query(
@@ -88,15 +88,12 @@ class LuceneSearch extends Search
                 $filter->setValue("0");
             }
 
-            $this->getContext()->getDataProvider()->addFilter($filter->create());
         } else {
-            if ((string)$value !== '') {
-                $filter = $this->filterBuilder->setConditionType('like')
-                    ->setField('serialized_data')
-                    ->setValue($value);
-
-                $this->getContext()->getDataProvider()->addFilter($filter->create());
-            }
+            $filter = $this->filterBuilder->setConditionType('like')
+                ->setField('serialized_data')
+                ->setValue($value);
         }
+
+        $this->getContext()->getDataProvider()->addFilter($filter->create());
     }
 }

--- a/Model/Indexer/LuceneSearch.php
+++ b/Model/Indexer/LuceneSearch.php
@@ -12,6 +12,7 @@ use Magento\Framework\View\Element\UiComponent\ContextInterface;
 use Magento\Framework\View\Element\UiComponentFactory;
 use Magento\Ui\Component\Filters\FilterModifier;
 use Magento\Ui\Component\Filters\Type\Search;
+use Aligent\AsyncEvents\Helper\Config as AsyncEventsConfig;
 
 class LuceneSearch extends Search
 {
@@ -22,6 +23,7 @@ class LuceneSearch extends Search
      * @param FilterModifier $filterModifier
      * @param ConnectionManager $connectionManager
      * @param Config $config
+     * @param AsyncEventsConfig $asyncEventsConfig
      * @param array $components
      * @param array $data
      */
@@ -32,6 +34,7 @@ class LuceneSearch extends Search
         FilterModifier $filterModifier,
         private readonly ConnectionManager $connectionManager,
         private readonly Config $config,
+        private readonly AsyncEventsConfig $asyncEventsConfig,
         array $components = [],
         array $data = []
     ) {
@@ -49,35 +52,51 @@ class LuceneSearch extends Search
      */
     public function prepare(): void
     {
-        $client = $this->connectionManager->getConnection();
         $value = $this->getContext()->getRequestParam('search');
-        $indexPrefix = $this->config->getIndexPrefix();
 
-        try {
-            $rawResponse = $client->query(
-                [
-                    'index' => $indexPrefix . '_async_event_*',
-                    'q' => $value,
-                    // the default page size is 10. The highest limit is 10000. If we want to traverse further, we will
-                    // have to use the search after parameter. There are no plans to implement this right now.
-                    'size' => 100
-                ]
-            );
+        if ($this->asyncEventsConfig->isIndexingEnabled()) {
+            $client = $this->connectionManager->getConnection();
+            $indexPrefix = $this->config->getIndexPrefix();
+            $filter = $this->filterBuilder->setConditionType('in')
+                ->setField($this->getName());
 
-            $rawDocuments = $rawResponse['hits']['hits'] ?? [];
-            $asyncEventIds = array_column($rawDocuments, '_id');
-
-            if (!empty($asyncEventIds)) {
-                $filter = $this->filterBuilder->setConditionType('in')
-                    ->setField($this->getName())
-                    ->setValue($asyncEventIds)
-                    ->create();
-
-                $this->getContext()->getDataProvider()->addFilter($filter);
+            if ($value === "") {
+                return;
             }
-        } catch (Exception) {
-            // Fallback to default filter search
-            parent::prepare();
+
+            try {
+                $rawResponse = $client->query(
+                    [
+                        'index' => $indexPrefix . '_async_event_*',
+                        'q' => $value,
+                        // the default page size is 10. The highest limit is 10000. If we want to traverse further, we
+                        // will  have to use the search after parameter. There are no plans to implement this right now.
+                        'size' => 100
+                    ]
+                );
+
+                $rawDocuments = $rawResponse['hits']['hits'] ?? [];
+                $asyncEventIds = array_column($rawDocuments, '_id');
+
+                if (!empty($asyncEventIds)) {
+                    $filter->setValue($asyncEventIds);
+                } else {
+                    $filter->setValue("0");
+                }
+            } catch (Exception) {
+                // If we're unable to connect to Elasticsearch, we'll return nothing
+                $filter->setValue("0");
+            }
+
+            $this->getContext()->getDataProvider()->addFilter($filter->create());
+        } else {
+            if ((string)$value !== '') {
+                $filter = $this->filterBuilder->setConditionType('like')
+                    ->setField('serialized_data')
+                    ->setValue($value);
+
+                $this->getContext()->getDataProvider()->addFilter($filter->create());
+            }
         }
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -101,6 +101,7 @@
 
     <type name="\Aligent\AsyncEvents\Model\Indexer\IndexStructure">
         <arguments>
+            <argument name="adapter" xsi:type="object">\Magento\Elasticsearch\Model\Adapter\Elasticsearch\Proxy</argument>
             <argument name="scopeResolver" xsi:type="object" shared="false">\Aligent\AsyncEvents\Model\Resolver\AsyncEvent</argument>
         </arguments>
     </type>
@@ -138,7 +139,7 @@
         </arguments>
     </virtualType>
 
-    <virtualType name="dataMapperAdapter" type="Magento\Elasticsearch\Model\Adapter\Elasticsearch">
+    <virtualType name="dataMapperAdapter" type="Magento\Elasticsearch\Model\Adapter\Elasticsearch\Proxy">
         <arguments>
             <argument name="batchDocumentDataMapper" xsi:type="object">\Aligent\AsyncEvents\Model\Adapter\BatchDataMapper\AsyncEventLogMapper</argument>
         </arguments>


### PR DESCRIPTION
The classes DI injected into the indexer action class contain the elasticsearch adapter `\Magento\Elasticsearch\Model\Adapter\Elasticsearch` which attempts to connect to the configured search engine when the object manager attempts to create it.

However, in cases where elasticsearch is not used it causes a problem as the class that's requiring it also fails instantiation as described in #60 

Ideally, this class shouldn't fail from being created so that the indexer is able to skip it when set in the admin.