### PR TITLE
:construction: Fix adapter proxy and update CI

### DIFF
--- a/.github/workflows/api-functional-tests.yml
+++ b/.github/workflows/api-functional-tests.yml
@@ -7,14 +7,21 @@ on:
 
 jobs:
   api-functional-test:
-    runs-on:  "ubuntu-latest"
+    runs-on: "ubuntu-latest"
 
     # Only run api tests on feature branches. Simple documentation updates, formatting can be ignored
     if: contains(github.head_ref, 'feature')
+    name: ${{ matrix.job_title }}
     strategy:
       fail-fast: true
       matrix:
-        magento: ["magento/project-community-edition:>=2.4.4 <2.4.5", "magento/project-community-edition:>=2.4.5 <2.4.6", "magento/project-community-edition:>=2.4.6 <2.4.7"]
+        magento:
+          [
+            "magento/project-community-edition:>=2.4.4 <2.4.5",
+            "magento/project-community-edition:>=2.4.5 <2.4.6",
+            "magento/project-community-edition:>=2.4.6 <2.4.7",
+            "magento/project-community-edition:>=2.4.7 <2.4.8",
+          ]
         include:
           - magento: magento/project-community-edition:>=2.4.4 <2.4.5
             php: 8.1
@@ -23,8 +30,8 @@ jobs:
             elasticsearch: "elasticsearch:7.16.3"
             rabbitmq: "rabbitmq:3.9-management"
             redis: "redis:6.2"
-            varnish: "varnish:7.0"
-            nginx: "nginx:1.18"
+            job_title: "2.4.4"
+
           - magento: magento/project-community-edition:>=2.4.5 <2.4.6
             php: 8.1
             composer: 2
@@ -32,17 +39,25 @@ jobs:
             elasticsearch: "elasticsearch:7.16.3"
             rabbitmq: "rabbitmq:3.9-management"
             redis: "redis:6.2"
-            varnish: "varnish:7.0"
-            nginx: "nginx:1.18"
+            job_title: "2.4.5"
+
           - magento: magento/project-community-edition:>=2.4.6 <2.4.7
-            php: 8.1
-            composer: 2
+            php: 8.2
+            composer: 2.2
             mysql: "mysql:8.0"
             elasticsearch: "elasticsearch:7.17.9"
-            rabbitmq: "rabbitmq:3.9-management"
+            rabbitmq: "rabbitmq:3.12-management"
             redis: "redis:7.0"
-            varnish: "varnish:7.1"
-            nginx: "nginx:1.18"
+            job_title: "2.4.6"
+
+          - magento: magento/project-community-edition:>=2.4.7 <2.4.8
+            php: 8.3
+            composer: 2.7
+            mysql: "mariadb:10.6"
+            elasticsearch: "elasticsearch:7.17.9"
+            rabbitmq: "rabbitmq:3.12-management"
+            redis: "redis:7.2"
+            job_title: "2.4.7"
 
     services:
       elasticsearch:
@@ -58,7 +73,7 @@ jobs:
           - 9200:9200
 
       mysql:
-        image:  ${{ matrix.mysql }}
+        image: ${{ matrix.mysql }}
         env:
           MYSQL_DATABASE: magento_functional_tests
           MYSQL_USER: user
@@ -77,7 +92,7 @@ jobs:
           - 5672:5672
           - 15672:15672
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set PHP Version
         uses: shivammathur/setup-php@v2
         with:
@@ -94,11 +109,11 @@ jobs:
       - uses: graycoreio/github-actions-magento2/get-magento-version@main
         id: magento-version
         with:
-          working-directory:  "../magento2"
+          working-directory: "../magento2"
 
       - name: Get Composer Cache Directory
         shell: bash
-        working-directory:  "../magento2"
+        working-directory: "../magento2"
         id: composer-cache
         run: |
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
@@ -111,7 +126,7 @@ jobs:
 
       - run: composer config repositories.local path $GITHUB_WORKSPACE
         name: Add Github Repo for Testing
-        working-directory:  "../magento2"
+        working-directory: "../magento2"
         shell: bash
 
       - run: |
@@ -119,18 +134,18 @@ jobs:
           composer config --no-interaction allow-plugins.laminas/laminas-dependency-plugin true
           composer config --no-interaction allow-plugins.magento/* true
         name: Fixup Composer Plugins
-        working-directory:  "../magento2"
+        working-directory: "../magento2"
 
       - run: composer require aligent/async-events "@dev" --no-update && composer install
         name: Require and attempt install
-        working-directory:  "../magento2"
+        working-directory: "../magento2"
         shell: bash
         env:
           COMPOSER_CACHE_DIR: ${{ steps.composer-cache.outputs.dir }}
           COMPOSER_AUTH: ${{ secrets.composer_auth }}
 
       - name: Replace Configuration Settings for env
-        working-directory:  ../magento2/dev/tests/api-functional
+        working-directory: ../magento2/dev/tests/api-functional
         run: |
           cp phpunit_rest.xml.dist phpunit_rest.xml
           cp config/install-config-mysql.php.dist config/install-config-mysql.php
@@ -148,5 +163,5 @@ jobs:
           php -S 127.0.0.1:8082 -t ./pub/ ./phpserver/router.php &
           sleep 5
           vendor/bin/phpunit -c $(pwd)/dev/tests/api-functional/phpunit_rest.xml vendor/aligent/async-events/Test/Api
-        working-directory:  ../magento2
+        working-directory: ../magento2
         name: Run API Functional Tests

--- a/.github/workflows/api-functional-tests.yml
+++ b/.github/workflows/api-functional-tests.yml
@@ -119,7 +119,7 @@ jobs:
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: "Cache Composer Packages"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: "composer | v5 | '' | ${{ hashFiles('composer.lock') }}"
           path: ${{ steps.composer-cache.outputs.dir }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -154,7 +154,7 @@ jobs:
           sed -i "s/'amqp-host' => 'localhost'/'amqp-host' => '127.0.0.1'/" etc/install-config-mysql.php.dist
           sed -i "s/'consumers-wait-for-messages' => '0'/'consumers-wait-for-messages' => '1'/" etc/install-config-mysql.php.dist
           mkdir etc/di/preferences/cli
-          cp ../../../vendor/aligent/magento-async-events/Test/_files/ce.php ./etc/di/preferences/cli
+          cp ../../../vendor/aligent/async-events/Test/_files/ce.php ./etc/di/preferences/cli
 
       - run: ../../../vendor/bin/phpunit ../../../vendor/aligent/async-events/Test/Integration
         working-directory: ../magento2/dev/tests/integration

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -119,7 +119,7 @@ jobs:
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: "Cache Composer Packages"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: "composer | v5 | '' | ${{ hashFiles('composer.lock') }}"
           path: ${{ steps.composer-cache.outputs.dir }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,14 +7,21 @@ on:
 
 jobs:
   integration-test:
-    runs-on:  "ubuntu-latest"
+    runs-on: "ubuntu-latest"
 
     # Only run integration tests on feature branches. Simple documentation updates, formatting can be ignored
     if: contains(github.head_ref, 'feature')
+    name: ${{ matrix.job_title }}
     strategy:
       fail-fast: true
       matrix:
-        magento: ["magento/project-community-edition:>=2.4.4 <2.4.5", "magento/project-community-edition:>=2.4.5 <2.4.6", "magento/project-community-edition:>=2.4.6 <2.4.7"]
+        magento:
+          [
+            "magento/project-community-edition:>=2.4.4 <2.4.5",
+            "magento/project-community-edition:>=2.4.5 <2.4.6",
+            "magento/project-community-edition:>=2.4.6 <2.4.7",
+            "magento/project-community-edition:>=2.4.7 <2.4.8",
+          ]
         include:
           - magento: magento/project-community-edition:>=2.4.4 <2.4.5
             php: 8.1
@@ -23,8 +30,8 @@ jobs:
             elasticsearch: "elasticsearch:7.16.3"
             rabbitmq: "rabbitmq:3.9-management"
             redis: "redis:6.2"
-            varnish: "varnish:7.0"
-            nginx: "nginx:1.18"
+            job_title: "2.4.4"
+
           - magento: magento/project-community-edition:>=2.4.5 <2.4.6
             php: 8.1
             composer: 2
@@ -32,17 +39,25 @@ jobs:
             elasticsearch: "elasticsearch:7.16.3"
             rabbitmq: "rabbitmq:3.9-management"
             redis: "redis:6.2"
-            varnish: "varnish:7.0"
-            nginx: "nginx:1.18"
+            job_title: "2.4.5"
+
           - magento: magento/project-community-edition:>=2.4.6 <2.4.7
-            php: 8.1
-            composer: 2
+            php: 8.2
+            composer: 2.2
             mysql: "mysql:8.0"
             elasticsearch: "elasticsearch:7.17.9"
-            rabbitmq: "rabbitmq:3.9-management"
+            rabbitmq: "rabbitmq:3.12-management"
             redis: "redis:7.0"
-            varnish: "varnish:7.1"
-            nginx: "nginx:1.18"
+            job_title: "2.4.6"
+
+          - magento: magento/project-community-edition:>=2.4.7 <2.4.8
+            php: 8.3
+            composer: 2.7
+            mysql: "mariadb:10.6"
+            elasticsearch: "elasticsearch:7.17.9"
+            rabbitmq: "rabbitmq:3.12-management"
+            redis: "redis:7.2"
+            job_title: "2.4.7"
 
     services:
       elasticsearch:
@@ -58,7 +73,7 @@ jobs:
           - 9200:9200
 
       mysql:
-        image:  ${{ matrix.mysql }}
+        image: ${{ matrix.mysql }}
         env:
           MYSQL_DATABASE: magento_integration_tests
           MYSQL_USER: user
@@ -77,7 +92,7 @@ jobs:
           - 5672:5672
           - 15672:15672
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set PHP Version
         uses: shivammathur/setup-php@v2
         with:
@@ -94,11 +109,11 @@ jobs:
       - uses: graycoreio/github-actions-magento2/get-magento-version@main
         id: magento-version
         with:
-          working-directory:  "../magento2"
+          working-directory: "../magento2"
 
       - name: Get Composer Cache Directory
         shell: bash
-        working-directory:  "../magento2"
+        working-directory: "../magento2"
         id: composer-cache
         run: |
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
@@ -111,7 +126,7 @@ jobs:
 
       - run: composer config repositories.local path $GITHUB_WORKSPACE
         name: Add Github Repo for Testing
-        working-directory:  "../magento2"
+        working-directory: "../magento2"
         shell: bash
 
       - run: |
@@ -119,25 +134,28 @@ jobs:
           composer config --no-interaction allow-plugins.laminas/laminas-dependency-plugin true
           composer config --no-interaction allow-plugins.magento/* true
         name: Fixup Composer Plugins
-        working-directory:  "../magento2"
+        working-directory: "../magento2"
 
       - run: composer require aligent/async-events "@dev" --no-update && composer install
         name: Require and attempt install
-        working-directory:  "../magento2"
+        working-directory: "../magento2"
         shell: bash
         env:
           COMPOSER_CACHE_DIR: ${{ steps.composer-cache.outputs.dir }}
           COMPOSER_AUTH: ${{ secrets.composer_auth }}
 
       - name: Replace Configuration Settings for env
-        working-directory:  ../magento2/dev/tests/integration
+        working-directory: ../magento2/dev/tests/integration
         run: |
           sed -i "s/'db-host' => 'localhost'/'db-host' => '127.0.0.1'/" etc/install-config-mysql.php.dist
           sed -i "s/'db-user' => 'root'/'db-user' => 'user'/" etc/install-config-mysql.php.dist
           sed -i "s/'db-password' => '123123q'/'db-password' => 'password'/" etc/install-config-mysql.php.dist
           sed -i "s/'elasticsearch-host' => 'localhost'/'elasticsearch-host' => '127.0.0.1'/" etc/install-config-mysql.php.dist
           sed -i "s/'amqp-host' => 'localhost'/'amqp-host' => '127.0.0.1'/" etc/install-config-mysql.php.dist
+          sed -i "s/'consumers-wait-for-messages' => '0'/'consumers-wait-for-messages' => '1'/" etc/install-config-mysql.php.dist
+          mkdir etc/di/preferences/cli
+          cp ../../../vendor/aligent/magento-async-events/Test/_files/ce.php ./etc/di/preferences/cli
 
       - run: ../../../vendor/bin/phpunit ../../../vendor/aligent/async-events/Test/Integration
-        working-directory:  ../magento2/dev/tests/integration
+        working-directory: ../magento2/dev/tests/integration
         name: Run Integration Tests

--- a/Test/Integration/EventRetryTest.php
+++ b/Test/Integration/EventRetryTest.php
@@ -22,11 +22,11 @@ class EventRetryTest extends TestCase
     /** @var PublisherInterface|null */
     private ?PublisherInterface $publisher;
 
-    /** @var PublisherConsumerController|null */
-    private ?PublisherConsumerController $publisherConsumerController;
-
     /** @var Json|null */
     private ?Json $json;
+
+    /** @var ResourceConnection|null */
+    private ?ResourceConnection $connection;
 
     protected function setUp(): void
     {
@@ -54,7 +54,6 @@ class EventRetryTest extends TestCase
      *
      * @magentoDataFixture Aligent_AsyncEvents::Test/_files/http_async_events.php
      * @magentoDbIsolation disabled
-     * @magentoConfigFixture default/system/async_events/max_deaths 3
      */
     public function testRetry()
     {
@@ -68,18 +67,23 @@ class EventRetryTest extends TestCase
             ]
         );
 
-        $this->publisherConsumerController = Bootstrap::getObjectManager()->create(
+        $consumerInitParams = Bootstrap::getInstance()->getAppInitParams();
+
+        $consumerInitParams['TESTS_BASE_DIR'] = INTEGRATION_TESTS_DIR;
+        $consumerInitParams['INTEGRATION_TESTS_CLI_AUTOLOADER'] = INTEGRATION_TESTS_DIR . '/framework/autoload.php';
+
+        $publisherConsumerController = Bootstrap::getObjectManager()->create(
             PublisherConsumerController::class,
             [
                 'consumers' => ['event.trigger.consumer', 'event.retry.consumer'],
                 'logFilePath' => TESTS_TEMP_DIR . "/MessageQueueTestLog.txt",
                 'maxMessages' => 10,
-                'appInitParams' => Bootstrap::getInstance()->getAppInitParams()
+                'appInitParams' => $consumerInitParams
             ]
         );
 
         try {
-            $this->publisherConsumerController->startConsumers();
+            $publisherConsumerController->startConsumers();
             sleep(16);
         } catch (EnvironmentPreconditionException $e) {
             $this->markTestSkipped($e->getMessage());
@@ -88,7 +92,7 @@ class EventRetryTest extends TestCase
                 $e->getMessage()
             );
         } finally {
-            $this->publisherConsumerController->stopConsumers();
+            $publisherConsumerController->stopConsumers();
         }
 
         $table = $this->connection->getTableName('async_event_subscriber_log');
@@ -100,8 +104,10 @@ class EventRetryTest extends TestCase
 
         $events = $connection->fetchAll($select);
 
+        $this->assertNotEmpty($events);
+
         foreach ($events as $event) {
-            // An uuid batch should be retired for 3 times after the first attempt. 1 + 3
+            // A batch should be retired for 3 times after the first attempt. 1 + 3
             $this->assertEquals(4, $event['events']);
         }
     }

--- a/Test/_files/ce.php
+++ b/Test/_files/ce.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Swap out Config for TestConfig during queue consumer run so `example.event` is available in Integration tests.
+ */
+
+return [
+    \Aligent\AsyncEvents\Model\Config::class => \Aligent\AsyncEvents\Test\Integration\TestConfig::class
+];

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -101,7 +101,7 @@
 
     <type name="\Aligent\AsyncEvents\Model\Indexer\IndexStructure">
         <arguments>
-            <argument name="adapter" xsi:type="object">\Magento\Elasticsearch\Model\Adapter\Elasticsearch\Proxy</argument>
+            <argument name="adapter" xsi:type="object">dataMapperAdapter</argument>
             <argument name="scopeResolver" xsi:type="object" shared="false">\Aligent\AsyncEvents\Model\Resolver\AsyncEvent</argument>
         </arguments>
     </type>


### PR DESCRIPTION
So it looks like it was a mistake and might have commited a previous version when testing the proxy object.

https://github.com/aligent/magento-async-events/pull/62/files#diff-093a1e43a11122404c853506b7ca4f661e18dd4f6557ec3089cad8ceae34a606L104

This should address the indexing cron job error